### PR TITLE
fix: フィード取得失敗でビルド全体が落ちる問題を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - name: Gatsby build (Netlifyと同等のビルド)
+        run: npm run build

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,20 +1,10 @@
 import type { GatsbyConfig } from 'gatsby';
-import rssFeeds from './src/utils/rssFeeds.json';
 
 const config: GatsbyConfig = {
     siteMetadata: {
         title: 'Tech Blog Aggregator',
     },
-    plugins: [
-        ...rssFeeds.map((feed) => ({
-            resolve: 'gatsby-source-rss-feed',
-            options: {
-                url: feed.feed,
-                name: feed.name,
-            },
-        })),
-        '@chakra-ui/gatsby-plugin',
-    ],
+    plugins: ['@chakra-ui/gatsby-plugin'],
 };
 
 export default config;

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,0 +1,96 @@
+import type { GatsbyNode } from 'gatsby';
+import Parser from 'rss-parser';
+import rssFeeds from './src/utils/rssFeeds.json';
+
+// フィードが1つも取れなくてもクエリが壊れないよう、型を明示的に定義しておく
+export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] =
+    ({ actions }) => {
+        actions.createTypes(`
+            type BlogPost implements Node {
+                title: String!
+                link: String!
+                pubDate: Date @dateformat
+                sourceName: String!
+                sourceTitle: String!
+                sourceLink: String!
+            }
+            type BlogSource implements Node {
+                name: String!
+                title: String!
+                link: String!
+                order: Int!
+            }
+        `);
+    };
+
+export const sourceNodes: GatsbyNode['sourceNodes'] = async ({
+    actions,
+    createNodeId,
+    createContentDigest,
+    reporter,
+}) => {
+    const parser = new Parser({ timeout: 20000 });
+
+    // 落ちているフィードはスキップして、取れたものだけでビルドを続行する
+    const results = await Promise.allSettled(
+        rssFeeds.map((feed) => parser.parseURL(feed.feed))
+    );
+
+    let okCount = 0;
+    results.forEach((result, i) => {
+        const feed = rssFeeds[i];
+        if (result.status === 'rejected') {
+            reporter.warn(
+                `[rss] ${feed.name} をスキップ: ${result.reason?.message ?? result.reason}`
+            );
+            return;
+        }
+        okCount++;
+
+        const parsed = result.value;
+        const sourceTitle = parsed.title?.trim() || feed.name;
+        const sourceLink = parsed.link || feed.site;
+
+        const sourceNode = {
+            name: feed.name,
+            title: sourceTitle,
+            link: sourceLink,
+            order: i,
+        };
+        actions.createNode({
+            ...sourceNode,
+            id: createNodeId(`BlogSource-${feed.name}`),
+            internal: {
+                type: 'BlogSource',
+                contentDigest: createContentDigest(sourceNode),
+            },
+        });
+
+        (parsed.items ?? []).forEach((item, j) => {
+            if (!item.title || !item.link) return;
+            const rawDate = item.isoDate ?? item.pubDate ?? null;
+            const pubDate =
+                rawDate && !Number.isNaN(new Date(rawDate).getTime())
+                    ? new Date(rawDate).toISOString()
+                    : null;
+            const postNode = {
+                title: item.title.trim(),
+                link: item.link,
+                pubDate,
+                sourceName: feed.name,
+                sourceTitle,
+                sourceLink,
+            };
+            actions.createNode({
+                ...postNode,
+                id: createNodeId(`BlogPost-${feed.name}-${item.link}-${j}`),
+                internal: {
+                    type: 'BlogPost',
+                    contentDigest: createContentDigest(postNode),
+                },
+            });
+        });
+    });
+
+    reporter.info(`[rss] ${okCount}/${rssFeeds.length} フィードの取得に成功`);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
                 "@emotion/styled": "^11.14.0",
                 "framer-motion": "^12.4.10",
                 "gatsby": "^5.14.1",
-                "gatsby-source-rss-feed": "^1.2.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "rss-parser": "^3.13.0"
@@ -9964,15 +9963,6 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            }
-        },
-        "node_modules/gatsby-source-rss-feed": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/gatsby-source-rss-feed/-/gatsby-source-rss-feed-1.2.2.tgz",
-            "integrity": "sha512-Ris5Dtdj856aups8xzPtNOG6prKjaGzcXxRdFrgExQBVv2o1fUPHwj7OGrdV32tNUg2mHOZurr5qFWAdaRIMUg==",
-            "dependencies": {
-                "lodash": "^4.17.15",
-                "rss-parser": "^3.7.6"
             }
         },
         "node_modules/gatsby-worker": {
@@ -24501,15 +24491,6 @@
             "integrity": "sha512-2lZg8NEg5M8jzkMYZouf0I5e1TVpwjtEiKg48R4dGOhYqDKGfENVJWRnvYtw12zNfgBgQ/gUryG7Zj7qMLVANA==",
             "requires": {
                 "sharp": "^0.32.6"
-            }
-        },
-        "gatsby-source-rss-feed": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/gatsby-source-rss-feed/-/gatsby-source-rss-feed-1.2.2.tgz",
-            "integrity": "sha512-Ris5Dtdj856aups8xzPtNOG6prKjaGzcXxRdFrgExQBVv2o1fUPHwj7OGrdV32tNUg2mHOZurr5qFWAdaRIMUg==",
-            "requires": {
-                "lodash": "^4.17.15",
-                "rss-parser": "^3.7.6"
             }
         },
         "gatsby-worker": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "@emotion/styled": "^11.14.0",
         "framer-motion": "^12.4.10",
         "gatsby": "^5.14.1",
-        "gatsby-source-rss-feed": "^1.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rss-parser": "^3.13.0"

--- a/src/pages/blogs.tsx
+++ b/src/pages/blogs.tsx
@@ -1,49 +1,29 @@
 import React from 'react';
 import Layout from '../components/layout';
 import { graphql, PageProps } from 'gatsby';
-import rssFeeds from '../utils/rssFeeds.json';
 import { Box, Link } from '@chakra-ui/react';
 
-type BlogPost = {
+type BlogSource = {
+    name: string;
     title: string;
     link: string;
 };
 
-type BlogData = {
-    [key: string]: { nodes: BlogPost[] };
+type DataProps = {
+    allBlogSource: { nodes: BlogSource[] };
 };
-
-type SiteData = {
-    [key: string]: BlogPost;
-};
-
-type DataProps = BlogData & SiteData;
 
 const BlogsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
     return (
         <Layout>
             <Box as='ul'>
-                {rssFeeds.map((rssFeed) => {
-                    const siteName = rssFeed.name;
-                    if (data[`feed${siteName}Meta`]) {
-                        return (
-                            <Box
-                                as='li'
-                                key={siteName}
-                                listStyleType={'none'}
-                                mb={4}
-                            >
-                                <Link
-                                    href={data[`feed${siteName}Meta`].link}
-                                    isExternal
-                                >
-                                    {data[`feed${siteName}Meta`].title}
-                                </Link>
-                            </Box>
-                        );
-                    }
-                    return null;
-                })}
+                {data.allBlogSource.nodes.map((source) => (
+                    <Box as='li' key={source.name} listStyleType={'none'} mb={4}>
+                        <Link href={source.link} isExternal>
+                            {source.title}
+                        </Link>
+                    </Box>
+                ))}
             </Box>
         </Layout>
     );
@@ -53,232 +33,9 @@ export default BlogsPage;
 
 export const query = graphql`
     query {
-        feedLineYahooMeta {
-            link
-            title
-        }
-        allFeedLineYahoo {
+        allBlogSource(sort: { order: ASC }) {
             nodes {
-                title
-                link
-            }
-        }
-        feedSakuraInternetMeta {
-            link
-            title
-        }
-        allFeedSakuraInternet {
-            nodes {
-                title
-                link
-            }
-        }
-        feedHatenaMeta {
-            link
-            title
-        }
-        allFeedHatena {
-            nodes {
-                title
-                link
-            }
-        }
-        feedGoogleMeta {
-            link
-            title
-        }
-        allFeedGoogle {
-            nodes {
-                title
-                link
-            }
-        }
-        feedDwangoMeta {
-            link
-            title
-        }
-        allFeedDwango {
-            nodes {
-                title
-                link
-            }
-        }
-        feedMixiMeta {
-            link
-            title
-        }
-        allFeedMixi {
-            nodes {
-                title
-                link
-            }
-        }
-        feedCyberAgentMeta {
-            link
-            title
-        }
-        allFeedCyberAgent {
-            nodes {
-                title
-                link
-            }
-        }
-        feedYumemiMeta {
-            link
-            title
-        }
-        allFeedYumemi {
-            nodes {
-                title
-                link
-            }
-        }
-        feedClassMethodMeta {
-            link
-            title
-        }
-        allFeedClassMethod {
-            nodes {
-                title
-                link
-            }
-        }
-        feedMercariMeta {
-            link
-            title
-        }
-        allFeedMercari {
-            nodes {
-                title
-                link
-            }
-        }
-        feedStudySapuriMeta {
-            link
-            title
-        }
-        allFeedStudySapuri {
-            nodes {
-                title
-                link
-            }
-        }
-        feedGunosyMeta {
-            link
-            title
-        }
-        allFeedGunosy {
-            nodes {
-                title
-                link
-            }
-        }
-        feedCookpadMeta {
-            link
-            title
-        }
-        allFeedCookpad {
-            nodes {
-                title
-                link
-            }
-        }
-        feedGurunaviMeta {
-            link
-            title
-        }
-        allFeedGurunavi {
-            nodes {
-                title
-                link
-            }
-        }
-        feedDelyMeta {
-            link
-            title
-        }
-        allFeedDely {
-            nodes {
-                title
-                link
-            }
-        }
-        feedKLabMeta {
-            link
-            title
-        }
-        allFeedKLab {
-            nodes {
-                title
-                link
-            }
-        }
-        feedMoneyForwardMeta {
-            link
-            title
-        }
-        allFeedMoneyForward {
-            nodes {
-                title
-                link
-            }
-        }
-        feedFreeeMeta {
-            link
-            title
-        }
-        allFeedFreee {
-            nodes {
-                title
-                link
-            }
-        }
-        feedZaimMeta {
-            link
-            title
-        }
-        allFeedZaim {
-            nodes {
-                title
-                link
-            }
-        }
-        feedWantedlyMeta {
-            link
-            title
-        }
-        allFeedWantedly {
-            nodes {
-                title
-                link
-            }
-        }
-        feedFindyMeta {
-            link
-            title
-        }
-        allFeedFindy {
-            nodes {
-                title
-                link
-            }
-        }
-        feedKaonaviMeta {
-            link
-            title
-        }
-        allFeedKaonavi {
-            nodes {
-                title
-                link
-            }
-        }
-        feedSansanMeta {
-            link
-            title
-        }
-        allFeedSansan {
-            nodes {
+                name
                 title
                 link
             }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,68 +1,68 @@
 import { graphql, PageProps } from 'gatsby';
 import React from 'react';
 import Layout from '../components/layout';
-import rssFeeds from '../utils/rssFeeds.json';
 import { Box, Heading, Link, List, ListItem } from '@chakra-ui/react';
 
 type BlogPost = {
     title: string;
     link: string;
-    pubDate?: string;
+    pubDate: string | null;
+    sourceName: string;
+    sourceTitle: string;
+    sourceLink: string;
 };
 
-type BlogData = {
-    [key: string]: { nodes: BlogPost[] };
+type BlogSource = {
+    name: string;
+    title: string;
+    link: string;
 };
 
-type SiteData = {
-    [key: string]: BlogPost;
+type DataProps = {
+    allBlogPost: { nodes: BlogPost[] };
+    allBlogSource: { nodes: BlogSource[] };
 };
-
-type DataProps = BlogData & SiteData;
 
 const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
+    const postsBySource = new Map<string, BlogPost[]>();
+    for (const post of data.allBlogPost.nodes) {
+        const posts = postsBySource.get(post.sourceName) ?? [];
+        posts.push(post);
+        postsBySource.set(post.sourceName, posts);
+    }
+
     return (
         <Layout>
-            {rssFeeds.map((rssFeed) => {
-                const siteName = rssFeed.name;
-                if (data[`allFeed${siteName}`] && data[`feed${siteName}Meta`]) {
-                    const meta = data[`feed${siteName}Meta`];
-                    const posts = data[`allFeed${siteName}`].nodes;
-
-                    return (
-                        <Box
-                            key={siteName}
-                            mb={8}
-                            borderBlockEnd={1}
-                            borderRadius='lg'
-                        >
-                            <Heading as='h2' size='md'>
-                                <Link href={meta.link} isExternal>
-                                    {meta.title}
-                                </Link>
-                            </Heading>
-                            <List spacing={2} mt={2} p={0}>
-                                {posts.map((post, index) => (
-                                    <Box mb={6}>
-                                        {post.pubDate ? (
-                                            <Box fontSize='ms'>
-                                                {new Date(
-                                                    post.pubDate
-                                                ).toLocaleString()}
-                                            </Box>
-                                        ) : null}
-                                        <ListItem key={index}>
-                                            <Link href={post.link} isExternal>
-                                                {post.title}
-                                            </Link>
-                                        </ListItem>
-                                    </Box>
-                                ))}
-                            </List>
-                        </Box>
-                    );
-                }
-                return null;
+            {data.allBlogSource.nodes.map((source) => {
+                const posts = postsBySource.get(source.name) ?? [];
+                return (
+                    <Box
+                        key={source.name}
+                        mb={8}
+                        borderBlockEnd={1}
+                        borderRadius='lg'
+                    >
+                        <Heading as='h2' size='md'>
+                            <Link href={source.link} isExternal>
+                                {source.title}
+                            </Link>
+                        </Heading>
+                        <List spacing={2} mt={2} p={0}>
+                            {posts.map((post) => (
+                                <Box mb={6} key={post.link}>
+                                    {post.pubDate ? (
+                                        <Box fontSize='ms'>{post.pubDate}</Box>
+                                    ) : null}
+                                    <ListItem>
+                                        <Link href={post.link} isExternal>
+                                            {post.title}
+                                        </Link>
+                                    </ListItem>
+                                </Box>
+                            ))}
+                        </List>
+                    </Box>
+                );
             })}
         </Layout>
     );
@@ -70,260 +70,23 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
 
 export default IndexPage;
 
-// TODO: クエリをまとめる
 export const query = graphql`
     query {
-        feedLineYahooMeta {
-            link
-            title
-        }
-        allFeedLineYahoo {
+        allBlogSource(sort: { order: ASC }) {
             nodes {
+                name
                 title
                 link
-                pubDate
             }
         }
-        feedSakuraInternetMeta {
-            link
-            title
-        }
-        allFeedSakuraInternet {
+        allBlogPost(sort: { pubDate: DESC }) {
             nodes {
                 title
                 link
-                pubDate
-            }
-        }
-        feedHatenaMeta {
-            link
-            title
-        }
-        allFeedHatena {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedGoogleMeta {
-            link
-            title
-        }
-        allFeedGoogle {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedDwangoMeta {
-            link
-            title
-        }
-        allFeedDwango {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedMixiMeta {
-            link
-            title
-        }
-        allFeedMixi {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedCyberAgentMeta {
-            link
-            title
-        }
-        allFeedCyberAgent {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedYumemiMeta {
-            link
-            title
-        }
-        allFeedYumemi {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedClassMethodMeta {
-            link
-            title
-        }
-        allFeedClassMethod {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedMercariMeta {
-            link
-            title
-        }
-        allFeedMercari {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedStudySapuriMeta {
-            link
-            title
-        }
-        allFeedStudySapuri {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedGunosyMeta {
-            link
-            title
-        }
-        allFeedGunosy {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedCookpadMeta {
-            link
-            title
-        }
-        allFeedCookpad {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedGurunaviMeta {
-            link
-            title
-        }
-        allFeedGurunavi {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedDelyMeta {
-            link
-            title
-        }
-        allFeedDely {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedKLabMeta {
-            link
-            title
-        }
-        allFeedKLab {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedMoneyForwardMeta {
-            link
-            title
-        }
-        allFeedMoneyForward {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedFreeeMeta {
-            link
-            title
-        }
-        allFeedFreee {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedZaimMeta {
-            link
-            title
-        }
-        allFeedZaim {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedWantedlyMeta {
-            link
-            title
-        }
-        allFeedWantedly {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedFindyMeta {
-            link
-            title
-        }
-        allFeedFindy {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedKaonaviMeta {
-            link
-            title
-        }
-        allFeedKaonavi {
-            nodes {
-                title
-                link
-                pubDate
-            }
-        }
-        feedSansanMeta {
-            link
-            title
-        }
-        allFeedSansan {
-            nodes {
-                title
-                link
-                pubDate
+                pubDate(formatString: "YYYY/MM/DD HH:mm")
+                sourceName
+                sourceTitle
+                sourceLink
             }
         }
     }


### PR DESCRIPTION
## 概要

Netlifyのビルドが `Deploy Preview failed` になっている問題への修正です。ビルド時に23個の外部RSSを取得する `gatsby-source-rss-feed` は、**1つでもフィードが落ちているとビルド全体が失敗する**構造でした。これを自前のフィード取得に置き換え、落ちているフィードをスキップして続行するようにします。

## 変更内容

- `gatsby-source-rss-feed` を廃止し、`gatsby-node.ts` の `sourceNodes` で `Promise.allSettled` により全フィードを取得(失敗フィードは警告してスキップ)
- `createSchemaCustomization` でスキーマを明示定義し、フィードが1件も取れなくてもGraphQLクエリが壊れないように
- `index.tsx` / `blogs.tsx` のフィードごとに手書きされていた300行超のGraphQLクエリを、`allBlogPost` / `allBlogSource` の汎用クエリに置き換え(表示は従来どおりサイト別グルーピング+日付表示)

## 検証

- `tsc --noEmit` 通過
- **全23フィードが取得不能な最悪ケースで `gatsby build` が完走(exit 0)することを確認**(トップ・/blogs・/digest の各ページ生成も確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TrbaN8q5ZwQjqshGbJCkd

---
_Generated by [Claude Code](https://claude.ai/code/session_014TrbaN8q5ZwQjqshGbJCkd)_