### PR TITLE
feat: ダイジェストの収集源をはてブ・Qiita・Zennに拡大

### DIFF
--- a/digests/2026-07-08.md
+++ b/digests/2026-07-08.md
@@ -1,0 +1,59 @@
+# Tech Blog Digest 2026-07-08
+
+## [Windows 11で空き容量が0バイトになる恐れ　影響を確認して速やかに対策を](https://news.mynavi.jp/techplus/article/20260707-4672951/)
+*news.mynavi.jp* (🔖404)
+
+> Windows Latestは7月6日(現地時間)、「Microsoft admits a Windows 11 bug is eating up to 500…
+
+## [「日本の会社員は全員これ読むべき」DeNAの南場智子会長が行っているAI活用方法が、経営者限らずどんな社会人でも参考になりそう](https://togetter.com/li/2718162)
+*togetter.com* (🔖294 / AI)
+
+> DeNA会長・南場智子のAI活用術5選がヤバかった AIを「便利な調べもの相手」として開いているなら、その実力の半分も引き出せていません。文章の要約、アイデア出…
+
+## [『めっちゃカメレオン』のサーバー代0円ってまじ？ - Qiita](https://qiita.com/i-icc/items/fb02ae5fa0848f4c511e)
+*qiita.com* (🔖237)
+
+> めっちゃカメレオン、流行ってますね 真っ白な体に絵を描いてステージに擬態する、新感覚のかくれんぼゲーム『めっちゃカメレオン』。 気づいたら世界的ヒットですよ こ…
+
+## [APIもDBも東京なのに、全クエリが太平洋横断していた話](https://zenn.dev/avaintelligence/articles/b7d4743a448485)
+*zenn.dev* (🔖147 / AI)
+
+> はじめに AI x 旅行アプリのアバトラベル（iOS / Android）は、2026年6月にフルリニューアルしました！ ところがその直後から、「ほぼ全てのAP…
+
+## [陸上自衛隊が使用したマルウェア入りUSBメモリについてまとめてみた - piyolog](https://piyolog.hatenadiary.jp/entry/2026/07/08/002522)
+*piyolog.hatenadiary.jp* (🔖129)
+
+> 防衛省・陸上自衛隊は、中部方面総監部(兵庫県伊丹市)が使用していたUSBメモリについて、2025年2月にマルウェアが含まれていることを検知した事例があったと公表…
+
+## [デザイナーの脳内をコピーして、誰でも90点以上のUIを作れるようにする｜トイ](https://note.com/toitoi1618/n/ndf35dbd2585b)
+*note.com* (🔖118 / AI)
+
+> こんにちは、令和トラベルでデザイナーをしているtoyです。 いま社内で、AIを前提にしたプロダクトデザイン環境を整えています。ひとことで言うと「デザイナー以外で…
+
+## [ローカル処理で画像から3Dモデルを生成する「Pixal3D」を使いこなす！【Blender ウォッチング】](https://forest.watch.impress.co.jp/docs/serial/blenderwthing/2123103.html)
+*forest.watch.impress.co.jp* (🔖80)
+
+## [わずか5MBのAIモデルをウェブサイトに組み込んでユーザーにローカル操作させられる「ternlight」が登場、ウェブサイトにAIを活用した検索機能などを追加可能](https://gigazine.net/news/20260707-ternlight-webassembly-embeddings/)
+*gigazine.net* (🔖59 / AI)
+
+> 「ternlight」はウェブサイトに軽量な埋め込みモデルを組み込めるパッケージです。埋め込みモデルのサイズは5～7MBで、ウェブサイト訪問者は自分のCPUで埋…
+
+## [最上位 AI モデルが「完全従量課金」になる日 〜 Claude Code で始めるモデルルーティング入門](https://blog.asial.co.jp/6980/)
+*blog.asial.co.jp* (🔖56 / AI)
+
+> エンジニアの又川です。 Anthropic の最上位モデル Claude Fable 5、もう使っていますか？ 7 月に入ってから、Claude Code には…
+
+## [ソフトウェア設計における抽象とメタの違い - kawasima](https://scrapbox.io/kawasima/%E3%82%BD%E3%83%95%E3%83%88%E3%82%A6%E3%82%A7%E3%82%A2%E8%A8%AD%E8%A8%88%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E6%8A%BD%E8%B1%A1%E3%81%A8%E3%83%A1%E3%82%BF%E3%81%AE%E9%81%95%E3%81%84)
+*scrapbox.io* (🔖53 / 設計)
+
+> ソフトウェアは、現実世界をそのまま扱えない。 たとえば、ある町の地図を描くとする。同じ町でも、目的が違えば描き方はまるで変わる。 路線図は、駅と乗り換えさえ分か…
+
+## [良かれと思って始まる「無駄」な施策から撤退する方法｜レバテックLAB - レバテックLAB](https://levtech.jp/media/detail_888/)
+*levtech.jp* (🔖43)
+
+> しんざき システムエンジニア、PM、ケーナ奏者、三児の父。南米民族音楽の演奏が趣味。仕事・育児・演奏活動の傍ら、レトロゲーム雑記ブログ「不倒城」を20年程運営し…
+
+## [IAMユーザーを持っていないメンバーや外部の人間とS3バケット上のオブジェクトをやり取りする際はStorage Browser for S3も検討しよう](https://dev.classmethod.jp/articles/storage-browser-for-s3-amplify/)
+*DevelopersIO* (🎲 セレンディピティ枠)
+
+> IAMユーザーを持たない外部ユーザーとのファイル共有を、低コストかつ運用負荷を抑えて実現する方法を検討します。従来のVPNやWorkSpacesではコストが高く…

--- a/digests/index.json
+++ b/digests/index.json
@@ -1,1 +1,127 @@
-[]
+[
+  {
+    "date": "2026-07-08",
+    "items": [
+      {
+        "title": "Windows 11で空き容量が0バイトになる恐れ　影響を確認して速やかに対策を",
+        "link": "https://news.mynavi.jp/techplus/article/20260707-4672951/",
+        "source": "news.mynavi.jp",
+        "hatebu": 404,
+        "summary": "Windows Latestは7月6日(現地時間)、「Microsoft admits a Windows 11 bug is eating up to 500…",
+        "matchedKeywords": [],
+        "serendipity": false
+      },
+      {
+        "title": "「日本の会社員は全員これ読むべき」DeNAの南場智子会長が行っているAI活用方法が、経営者限らずどんな社会人でも参考になりそう",
+        "link": "https://togetter.com/li/2718162",
+        "source": "togetter.com",
+        "hatebu": 294,
+        "summary": "DeNA会長・南場智子のAI活用術5選がヤバかった AIを「便利な調べもの相手」として開いているなら、その実力の半分も引き出せていません。文章の要約、アイデア出…",
+        "matchedKeywords": [
+          "AI"
+        ],
+        "serendipity": false
+      },
+      {
+        "title": "『めっちゃカメレオン』のサーバー代0円ってまじ？ - Qiita",
+        "link": "https://qiita.com/i-icc/items/fb02ae5fa0848f4c511e",
+        "source": "qiita.com",
+        "hatebu": 237,
+        "summary": "めっちゃカメレオン、流行ってますね 真っ白な体に絵を描いてステージに擬態する、新感覚のかくれんぼゲーム『めっちゃカメレオン』。 気づいたら世界的ヒットですよ こ…",
+        "matchedKeywords": [],
+        "serendipity": false
+      },
+      {
+        "title": "APIもDBも東京なのに、全クエリが太平洋横断していた話",
+        "link": "https://zenn.dev/avaintelligence/articles/b7d4743a448485",
+        "source": "zenn.dev",
+        "hatebu": 147,
+        "summary": "はじめに AI x 旅行アプリのアバトラベル（iOS / Android）は、2026年6月にフルリニューアルしました！ ところがその直後から、「ほぼ全てのAP…",
+        "matchedKeywords": [
+          "AI"
+        ],
+        "serendipity": false
+      },
+      {
+        "title": "陸上自衛隊が使用したマルウェア入りUSBメモリについてまとめてみた - piyolog",
+        "link": "https://piyolog.hatenadiary.jp/entry/2026/07/08/002522",
+        "source": "piyolog.hatenadiary.jp",
+        "hatebu": 129,
+        "summary": "防衛省・陸上自衛隊は、中部方面総監部(兵庫県伊丹市)が使用していたUSBメモリについて、2025年2月にマルウェアが含まれていることを検知した事例があったと公表…",
+        "matchedKeywords": [],
+        "serendipity": false
+      },
+      {
+        "title": "デザイナーの脳内をコピーして、誰でも90点以上のUIを作れるようにする｜トイ",
+        "link": "https://note.com/toitoi1618/n/ndf35dbd2585b",
+        "source": "note.com",
+        "hatebu": 118,
+        "summary": "こんにちは、令和トラベルでデザイナーをしているtoyです。 いま社内で、AIを前提にしたプロダクトデザイン環境を整えています。ひとことで言うと「デザイナー以外で…",
+        "matchedKeywords": [
+          "AI"
+        ],
+        "serendipity": false
+      },
+      {
+        "title": "ローカル処理で画像から3Dモデルを生成する「Pixal3D」を使いこなす！【Blender ウォッチング】",
+        "link": "https://forest.watch.impress.co.jp/docs/serial/blenderwthing/2123103.html",
+        "source": "forest.watch.impress.co.jp",
+        "hatebu": 80,
+        "summary": "",
+        "matchedKeywords": [],
+        "serendipity": false
+      },
+      {
+        "title": "わずか5MBのAIモデルをウェブサイトに組み込んでユーザーにローカル操作させられる「ternlight」が登場、ウェブサイトにAIを活用した検索機能などを追加可能",
+        "link": "https://gigazine.net/news/20260707-ternlight-webassembly-embeddings/",
+        "source": "gigazine.net",
+        "hatebu": 59,
+        "summary": "「ternlight」はウェブサイトに軽量な埋め込みモデルを組み込めるパッケージです。埋め込みモデルのサイズは5～7MBで、ウェブサイト訪問者は自分のCPUで埋…",
+        "matchedKeywords": [
+          "AI"
+        ],
+        "serendipity": false
+      },
+      {
+        "title": "最上位 AI モデルが「完全従量課金」になる日 〜 Claude Code で始めるモデルルーティング入門",
+        "link": "https://blog.asial.co.jp/6980/",
+        "source": "blog.asial.co.jp",
+        "hatebu": 56,
+        "summary": "エンジニアの又川です。 Anthropic の最上位モデル Claude Fable 5、もう使っていますか？ 7 月に入ってから、Claude Code には…",
+        "matchedKeywords": [
+          "AI"
+        ],
+        "serendipity": false
+      },
+      {
+        "title": "ソフトウェア設計における抽象とメタの違い - kawasima",
+        "link": "https://scrapbox.io/kawasima/%E3%82%BD%E3%83%95%E3%83%88%E3%82%A6%E3%82%A7%E3%82%A2%E8%A8%AD%E8%A8%88%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E6%8A%BD%E8%B1%A1%E3%81%A8%E3%83%A1%E3%82%BF%E3%81%AE%E9%81%95%E3%81%84",
+        "source": "scrapbox.io",
+        "hatebu": 53,
+        "summary": "ソフトウェアは、現実世界をそのまま扱えない。 たとえば、ある町の地図を描くとする。同じ町でも、目的が違えば描き方はまるで変わる。 路線図は、駅と乗り換えさえ分か…",
+        "matchedKeywords": [
+          "設計"
+        ],
+        "serendipity": false
+      },
+      {
+        "title": "良かれと思って始まる「無駄」な施策から撤退する方法｜レバテックLAB - レバテックLAB",
+        "link": "https://levtech.jp/media/detail_888/",
+        "source": "levtech.jp",
+        "hatebu": 43,
+        "summary": "しんざき システムエンジニア、PM、ケーナ奏者、三児の父。南米民族音楽の演奏が趣味。仕事・育児・演奏活動の傍ら、レトロゲーム雑記ブログ「不倒城」を20年程運営し…",
+        "matchedKeywords": [],
+        "serendipity": false
+      },
+      {
+        "title": "IAMユーザーを持っていないメンバーや外部の人間とS3バケット上のオブジェクトをやり取りする際はStorage Browser for S3も検討しよう",
+        "link": "https://dev.classmethod.jp/articles/storage-browser-for-s3-amplify/",
+        "source": "DevelopersIO",
+        "hatebu": 0,
+        "summary": "IAMユーザーを持たない外部ユーザーとのファイル共有を、低コストかつ運用負荷を抑えて実現する方法を検討します。従来のVPNやWorkSpacesではコストが高く…",
+        "matchedKeywords": [],
+        "serendipity": true
+      }
+    ]
+  }
+]

--- a/scripts/digest/collect.mjs
+++ b/scripts/digest/collect.mjs
@@ -4,24 +4,87 @@ import { fileURLToPath } from 'node:url';
 import Parser from 'rss-parser';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const feeds = JSON.parse(
+const companyFeeds = JSON.parse(
     fs.readFileSync(path.join(here, '../../src/utils/rssFeeds.json'), 'utf8')
 );
 
 const parser = new Parser({ timeout: 15000 });
 
 /**
- * 全フィードから記事を収集し、lookbackHours 以内のものだけ返す。
+ * 重複排除キー用にURLを正規化する。
+ * 同一記事が企業ブログRSSとはてブ/Qiita/Zenn経由で二重に届くため、
+ * トラッキング用クエリとフラグメントを落として同一視する。
+ */
+function normalizeUrl(raw) {
+    try {
+        const url = new URL(raw);
+        url.hash = '';
+        for (const key of [...url.searchParams.keys()]) {
+            if (key.startsWith('utm_') || key === 'ref' || key === 'source') {
+                url.searchParams.delete(key);
+            }
+        }
+        url.pathname = url.pathname.replace(/\/+$/, '');
+        return url.toString();
+    } catch {
+        return raw;
+    }
+}
+
+function safeHostname(link) {
+    try {
+        return link ? new URL(link).hostname : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 収集対象フィードの一覧を組み立てる。
+ * 企業ブログ(rssFeeds.json) + 集約フィード + 興味トピック別のQiita/Zennフィード。
+ * 企業ブログを先頭に置き、重複時はスニペットが充実している企業ブログ側を残す。
+ */
+function buildFeedList(config) {
+    const feeds = companyFeeds.map((feed) => ({
+        name: feed.name,
+        feed: feed.feed,
+        aggregator: false,
+    }));
+    for (const agg of config.aggregatorFeeds ?? []) {
+        feeds.push({ ...agg, aggregator: true });
+    }
+    for (const topic of config.topics ?? []) {
+        feeds.push({
+            name: `Qiita/${topic}`,
+            feed: `https://qiita.com/tags/${encodeURIComponent(topic)}/feed`,
+            aggregator: true,
+        });
+        feeds.push({
+            name: `Zenn/${topic}`,
+            feed: `https://zenn.dev/topics/${encodeURIComponent(topic)}/feed`,
+            aggregator: true,
+        });
+    }
+    return feeds;
+}
+
+/**
+ * 全フィードから記事を収集し、lookbackHours 以内のものをURL重複排除して返す。
  * 一部のフィードが落ちていても全体は止めない。
  */
-export async function collect(lookbackHours) {
-    const since = Date.now() - lookbackHours * 60 * 60 * 1000;
+export async function collect(config) {
+    const since = Date.now() - config.lookbackHours * 60 * 60 * 1000;
+    const feeds = buildFeedList(config);
 
     const results = await Promise.allSettled(
         feeds.map(async (feed) => {
             const parsed = await parser.parseURL(feed.feed);
             return (parsed.items ?? []).map((item) => ({
-                source: parsed.title ?? feed.name,
+                // 集約フィードでは配信元ドメインを表示名にする(feed名は経由地でしかない)
+                source: feed.aggregator
+                    ? safeHostname(item.link) ?? feed.name
+                    : parsed.title ?? feed.name,
+                via: feed.name,
                 title: item.title?.trim() ?? '(no title)',
                 link: item.link ?? '',
                 publishedAt: item.isoDate ?? item.pubDate ?? null,
@@ -30,19 +93,30 @@ export async function collect(lookbackHours) {
         })
     );
 
-    const items = [];
+    const deduped = new Map();
+    let okCount = 0;
     results.forEach((result, i) => {
-        if (result.status === 'fulfilled') {
-            items.push(...result.value);
-        } else {
-            console.warn(`[collect] ${feeds[i].name} の取得に失敗: ${result.reason?.message ?? result.reason}`);
+        if (result.status === 'rejected') {
+            console.warn(
+                `[collect] ${feeds[i].name} の取得に失敗: ${result.reason?.message ?? result.reason}`
+            );
+            return;
+        }
+        okCount++;
+        for (const item of result.value) {
+            if (!item.link || !item.publishedAt) continue;
+            if (new Date(item.publishedAt).getTime() < since) continue;
+            const key = normalizeUrl(item.link);
+            const existing = deduped.get(key);
+            // 先勝ち(企業ブログ優先)。ただしスニペットが空なら後続で補完する
+            if (!existing) {
+                deduped.set(key, item);
+            } else if (!existing.snippet && item.snippet) {
+                deduped.set(key, { ...existing, snippet: item.snippet });
+            }
         }
     });
 
-    return items.filter(
-        (item) =>
-            item.link &&
-            item.publishedAt &&
-            new Date(item.publishedAt).getTime() >= since
-    );
+    console.log(`[collect] フィード取得: ${okCount}/${feeds.length} 件成功`);
+    return [...deduped.values()];
 }

--- a/scripts/digest/config.json
+++ b/scripts/digest/config.json
@@ -1,5 +1,5 @@
 {
-    "maxItems": 10,
+    "maxItems": 12,
     "serendipityCount": 1,
     "lookbackHours": 24,
     "keywordBoost": 10,
@@ -11,6 +11,26 @@
         "セキュリティ",
         "LLM",
         "AI"
+    ],
+    "topics": [
+        "typescript",
+        "react",
+        "aws",
+        "llm"
+    ],
+    "aggregatorFeeds": [
+        {
+            "name": "はてブIT人気",
+            "feed": "https://b.hatena.ne.jp/hotentry/it.rss"
+        },
+        {
+            "name": "Qiitaトレンド",
+            "feed": "https://qiita.com/popular-items/feed"
+        },
+        {
+            "name": "Zennトレンド",
+            "feed": "https://zenn.dev/feed"
+        }
     ],
     "summary": {
         "model": "claude-haiku-4-5",

--- a/scripts/digest/run.mjs
+++ b/scripts/digest/run.mjs
@@ -10,7 +10,7 @@ import { jstDateString, postToSlack, updateJsonIndex, writeMarkdown } from './de
 const here = path.dirname(fileURLToPath(import.meta.url));
 const config = JSON.parse(fs.readFileSync(path.join(here, 'config.json'), 'utf8'));
 
-const collected = await collect(config.lookbackHours);
+const collected = await collect(config);
 console.log(`[run] 過去${config.lookbackHours}時間の記事: ${collected.length}件`);
 
 const enriched = await enrichWithHatebu(collected);


### PR DESCRIPTION
## 概要

デイリーダイジェストの収集源を23社の企業ブログRSSから、はてなブックマーク・Qiita・Zennを含む34フィードに拡大する。

## 変更内容

- **集約フィードの追加** (`config.json` の `aggregatorFeeds`)
  - はてなブックマーク テクノロジー人気エントリ
  - Qiitaトレンド / Zennトレンド
- **興味トピック購読** (`config.json` の `topics`): typescript, react, aws, llm → Qiita/Zennのタグ別フィードURLを自動生成
- **重複排除**: 同一記事が企業ブログとはてブ/Qiita/Zenn経由で二重に届くため、URL正規化（utm等のトラッキングパラメータ・フラグメント除去）で同一視。企業ブログ側を優先して残す
- 集約フィード経由の記事は配信元ドメイン（例: `zenn.dev`）を表示名にする
- `maxItems` 10→12
- テスト実行で生成された 2026-07-08 のダイジェストを同梱（マージ後 `/digest` ページに即反映）

## テスト

- `npm run digest`: 33/34フィード成功、104記事収集→12件選抜（Zaimの406は既存問題、スキップ動作は設計どおり）
- `npm run typecheck`: ✅
- `gatsby build`: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9pFdJSDgEGi2mK1TSgnVv