### PR TITLE
feat: 保存済み機能を追加

### DIFF
--- a/src/hooks/useReadState.ts
+++ b/src/hooks/useReadState.ts
@@ -1,9 +1,20 @@
 import { useCallback } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 
+export type SavedArticle = {
+    title: string;
+    link: string;
+    source: string;
+    publishedAt?: string | null;
+    hatebu?: number;
+    summary?: string;
+    matchedKeywords?: string[];
+    savedAt: string;
+};
+
 export function useReadState() {
     const [readLinks, setReadLinks] = useLocalStorage<string[]>('mizuo:read', []);
-    const [savedLinks, setSavedLinks] = useLocalStorage<string[]>('mizuo:saved', []);
+    const [savedArticles, setSavedArticles] = useLocalStorage<SavedArticle[]>('mizuo:saved', []);
 
     const markRead = useCallback(
         (link: string) => {
@@ -15,14 +26,14 @@ export function useReadState() {
     );
 
     const toggleSaved = useCallback(
-        (link: string) => {
-            setSavedLinks((prev) =>
-                prev.includes(link)
-                    ? prev.filter((l) => l !== link)
-                    : [...prev, link]
-            );
+        (article: SavedArticle) => {
+            setSavedArticles((prev) => {
+                const exists = prev.some((a) => a.link === article.link);
+                if (exists) return prev.filter((a) => a.link !== article.link);
+                return [{ ...article, savedAt: new Date().toISOString() }, ...prev];
+            });
         },
-        [setSavedLinks]
+        [setSavedArticles]
     );
 
     const isRead = useCallback(
@@ -31,9 +42,9 @@ export function useReadState() {
     );
 
     const isSaved = useCallback(
-        (link: string) => savedLinks.includes(link),
-        [savedLinks]
+        (link: string) => savedArticles.some((a) => a.link === link),
+        [savedArticles]
     );
 
-    return { markRead, toggleSaved, isRead, isSaved, savedLinks };
+    return { markRead, toggleSaved, isRead, isSaved, savedArticles };
 }

--- a/src/pages/digest.tsx
+++ b/src/pages/digest.tsx
@@ -40,12 +40,7 @@ const DigestPage: React.FC = () => {
 
             {days.map((day) => (
                 <Box key={day.date} mb={10}>
-                    <Text
-                        fontSize='sm'
-                        fontWeight='semibold'
-                        color='neutral.textSecondary'
-                        mb={3}
-                    >
+                    <Text fontSize='sm' fontWeight='semibold' color='neutral.textSecondary' mb={3}>
                         {day.date}
                     </Text>
 
@@ -69,7 +64,17 @@ const DigestPage: React.FC = () => {
                                 isRead={isRead(item.link)}
                                 isSaved={isSaved(item.link)}
                                 onRead={() => markRead(item.link)}
-                                onSave={() => toggleSaved(item.link)}
+                                onSave={() =>
+                                    toggleSaved({
+                                        title: item.title,
+                                        link: item.link,
+                                        source: item.source,
+                                        hatebu: item.hatebu,
+                                        summary: item.summary,
+                                        matchedKeywords: item.matchedKeywords,
+                                        savedAt: '',
+                                    })
+                                }
                             />
                         ))}
                     </Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -75,28 +75,51 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
                         sideItems={sideItems}
                         isSaved={isSaved(hero.link)}
                         onRead={() => markRead(hero.link)}
-                        onSave={() => toggleSaved(hero.link)}
+                        onSave={() =>
+                            toggleSaved({
+                                title: hero.title,
+                                link: hero.link,
+                                source: hero.sourceTitle,
+                                publishedAt: hero.pubDate,
+                                matchedKeywords: TOPICS.filter((kw) =>
+                                    hero.title.toLowerCase().includes(kw.toLowerCase())
+                                ),
+                                savedAt: '',
+                            })
+                        }
                     />
                 </Box>
             )}
 
             <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
-                {rest.slice(4).map((post) => (
-                    <ArticleCard
-                        key={post.link}
-                        title={post.title}
-                        link={post.link}
-                        source={post.sourceTitle}
-                        publishedAt={post.pubDate ? new Date(post.pubDate) : null}
-                        matchedKeywords={TOPICS.filter((kw) =>
-                            post.title.toLowerCase().includes(kw.toLowerCase())
-                        )}
-                        isRead={isRead(post.link)}
-                        isSaved={isSaved(post.link)}
-                        onRead={() => markRead(post.link)}
-                        onSave={() => toggleSaved(post.link)}
-                    />
-                ))}
+                {rest.slice(4).map((post) => {
+                    const matchedKeywords = TOPICS.filter((kw) =>
+                        post.title.toLowerCase().includes(kw.toLowerCase())
+                    );
+                    return (
+                        <ArticleCard
+                            key={post.link}
+                            title={post.title}
+                            link={post.link}
+                            source={post.sourceTitle}
+                            publishedAt={post.pubDate ? new Date(post.pubDate) : null}
+                            matchedKeywords={matchedKeywords}
+                            isRead={isRead(post.link)}
+                            isSaved={isSaved(post.link)}
+                            onRead={() => markRead(post.link)}
+                            onSave={() =>
+                                toggleSaved({
+                                    title: post.title,
+                                    link: post.link,
+                                    source: post.sourceTitle,
+                                    publishedAt: post.pubDate,
+                                    matchedKeywords,
+                                    savedAt: '',
+                                })
+                            }
+                        />
+                    );
+                })}
             </SimpleGrid>
         </Layout>
     );

--- a/src/pages/saved.tsx
+++ b/src/pages/saved.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Flex, Text } from '@chakra-ui/react';
+import Layout from '../components/layout';
+import { ArticleCard } from '../components/ArticleCard/ArticleCard';
+import { EmptyState } from '../components/EmptyState/EmptyState';
+import { useReadState, type SavedArticle } from '../hooks/useReadState';
+
+const SavedPage: React.FC = () => {
+    const { savedArticles, toggleSaved, isRead, markRead } = useReadState();
+    // SSRと一致させるため、ハイドレーション後に描画する
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => { setMounted(true); }, []);
+
+    if (!mounted) return <Layout><Box /></Layout>;
+
+    return (
+        <Layout>
+            <Flex align='baseline' gap={3} mb={5}>
+                <Text fontWeight='bold' fontSize='xl' color='neutral.textPrimary'>
+                    保存済み
+                </Text>
+                {savedArticles.length > 0 && (
+                    <Text fontSize='sm' color='neutral.textSecondary'>
+                        {savedArticles.length}件
+                    </Text>
+                )}
+            </Flex>
+
+            {savedArticles.length === 0 && (
+                <EmptyState
+                    message='保存した記事はありません'
+                    sub='記事の ☆ をタップして保存できます'
+                />
+            )}
+
+            <Box display='flex' flexDirection='column' gap={3}>
+                {savedArticles.map((article: SavedArticle) => (
+                    <ArticleCard
+                        key={article.link}
+                        title={article.title}
+                        link={article.link}
+                        source={article.source}
+                        publishedAt={article.publishedAt ? new Date(article.publishedAt) : null}
+                        hatebu={article.hatebu}
+                        summary={article.summary}
+                        matchedKeywords={article.matchedKeywords}
+                        isRead={isRead(article.link)}
+                        isSaved={true}
+                        onRead={() => markRead(article.link)}
+                        onSave={() => toggleSaved(article)}
+                    />
+                ))}
+            </Box>
+        </Layout>
+    );
+};
+
+export default SavedPage;


### PR DESCRIPTION
## 概要

NavBarの「保存済み」タブに対応するページと、記事メタデータの永続化を実装。

## 変更内容

### `useReadState.ts`
- `savedLinks: string[]` → `savedArticles: SavedArticle[]` に拡張
- `SavedArticle` 型: title / link / source / publishedAt / hatebu / summary / matchedKeywords / savedAt
- `toggleSaved(article)` で保存・解除をトグル（新規は先頭に追加）

### `src/pages/saved.tsx`（新規）
- localStorage の保存記事を新着順で一覧表示
- 件数バッジ表示
- ☆ タップで保存解除
- SSR安全: `useEffect` でハイドレーション後に描画

### `index.tsx` / `digest.tsx`
- `onSave` の呼び出しを `toggleSaved(article)` 形式に更新

## テスト

- `typecheck`: ✅
- `gatsby build`: `/saved/` ページが生成されることを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01B9pFdJSDgEGi2mK1TSgnVv