### PR TITLE
feat: SupabaseとGitHub OAuthによる保存記事の永続化

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,27 @@
+name: DB Migration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Supabaseプロジェクトにリンク
+        run: supabase link --project-ref pzhqwtbdjzzhhlzxluez
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: マイグレーション適用
+        run: supabase db push --password "${{ secrets.SUPABASE_DB_PASSWORD }}"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .cache/
 public
 src/gatsby-types.d.ts
+.env*
+!.env.example

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AuthProvider } from './src/contexts/AuthContext';
+
+export const wrapRootElement = ({ element }: { element: React.ReactNode }) => (
+    <AuthProvider>{element}</AuthProvider>
+);

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AuthProvider } from './src/contexts/AuthContext';
+
+export const wrapRootElement = ({ element }: { element: React.ReactNode }) => (
+    <AuthProvider>{element}</AuthProvider>
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@chakra-ui/react": "^2.10.6",
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.0",
+                "@supabase/supabase-js": "^2.110.2",
                 "framer-motion": "^12.4.10",
                 "gatsby": "^5.14.1",
                 "react": "^18.2.0",
@@ -5719,6 +5720,120 @@
             },
             "peerDependencies": {
                 "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+            }
+        },
+        "node_modules/@supabase/auth-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.2.tgz",
+            "integrity": "sha512-Qj7a6EDP+AMMQFWqGv+qFa8r6re//dk+qQI5bA0KK+PZmnI3JPu97TDeNt6SMiQ2FkklP79hP2yDFYSnA989OA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@supabase/auth-js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/@supabase/functions-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.2.tgz",
+            "integrity": "sha512-ZjjqrXpxM9/rE+eAtZxiK45EWy9EBoJQ322Q5Y75LccYQNh212neHTgXP/o4MIzmH0LNXT8UzvTZtQOfOzyoeQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@supabase/functions-js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/@supabase/phoenix": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+            "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+            "license": "MIT"
+        },
+        "node_modules/@supabase/postgrest-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.2.tgz",
+            "integrity": "sha512-++LBmcIMwCtgO4tISQUmo9+2xkRwHQqS8ZKMCnhXLe9P8k8YQRXuMoh/RiSzQSoev8gqet0W7yOboW0cUxnt0Q==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@supabase/postgrest-js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/@supabase/realtime-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.2.tgz",
+            "integrity": "sha512-z3jTOTPgyn6E3r6dVOOQ10He4yAMB2czjFw7xVdX3s16MHElna5rY1gVaePs0NIo6xvtMYbtmOXlFaFt/ePLpg==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/phoenix": "0.4.4",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@supabase/realtime-js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/@supabase/storage-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.2.tgz",
+            "integrity": "sha512-EhsRSwSnmQefKJsAxoRUZ0hvHr92ECM8DDGAKR5z0HdoJx4heI60PjHUTruVNZxKX6XeobLGDyLud020Bw1iwg==",
+            "license": "MIT",
+            "dependencies": {
+                "iceberg-js": "^0.8.1",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@supabase/storage-js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/@supabase/supabase-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.2.tgz",
+            "integrity": "sha512-r9q9w4ZQ6mOjh36aqUNFSisBF611vzpO8JphBESr2Q1SWvmGFQeI7Jq7Y+PaNMZ6Zszz+S2yTlJStCpnaMSnQg==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/auth-js": "2.110.2",
+                "@supabase/functions-js": "2.110.2",
+                "@supabase/postgrest-js": "2.110.2",
+                "@supabase/realtime-js": "2.110.2",
+                "@supabase/storage-js": "2.110.2"
+            },
+            "engines": {
+                "node": ">=22.0.0"
             }
         },
         "node_modules/@swc/helpers": {
@@ -12303,6 +12418,15 @@
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/iceberg-js": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+            "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/iconv-lite": {
@@ -22712,6 +22836,100 @@
             "integrity": "sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==",
             "dev": true
         },
+        "@supabase/auth-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.2.tgz",
+            "integrity": "sha512-Qj7a6EDP+AMMQFWqGv+qFa8r6re//dk+qQI5bA0KK+PZmnI3JPu97TDeNt6SMiQ2FkklP79hP2yDFYSnA989OA==",
+            "requires": {
+                "tslib": "2.8.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                }
+            }
+        },
+        "@supabase/functions-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.2.tgz",
+            "integrity": "sha512-ZjjqrXpxM9/rE+eAtZxiK45EWy9EBoJQ322Q5Y75LccYQNh212neHTgXP/o4MIzmH0LNXT8UzvTZtQOfOzyoeQ==",
+            "requires": {
+                "tslib": "2.8.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                }
+            }
+        },
+        "@supabase/phoenix": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+            "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+        },
+        "@supabase/postgrest-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.2.tgz",
+            "integrity": "sha512-++LBmcIMwCtgO4tISQUmo9+2xkRwHQqS8ZKMCnhXLe9P8k8YQRXuMoh/RiSzQSoev8gqet0W7yOboW0cUxnt0Q==",
+            "requires": {
+                "tslib": "2.8.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                }
+            }
+        },
+        "@supabase/realtime-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.2.tgz",
+            "integrity": "sha512-z3jTOTPgyn6E3r6dVOOQ10He4yAMB2czjFw7xVdX3s16MHElna5rY1gVaePs0NIo6xvtMYbtmOXlFaFt/ePLpg==",
+            "requires": {
+                "@supabase/phoenix": "0.4.4",
+                "tslib": "2.8.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                }
+            }
+        },
+        "@supabase/storage-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.2.tgz",
+            "integrity": "sha512-EhsRSwSnmQefKJsAxoRUZ0hvHr92ECM8DDGAKR5z0HdoJx4heI60PjHUTruVNZxKX6XeobLGDyLud020Bw1iwg==",
+            "requires": {
+                "iceberg-js": "^0.8.1",
+                "tslib": "2.8.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                }
+            }
+        },
+        "@supabase/supabase-js": {
+            "version": "2.110.2",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.2.tgz",
+            "integrity": "sha512-r9q9w4ZQ6mOjh36aqUNFSisBF611vzpO8JphBESr2Q1SWvmGFQeI7Jq7Y+PaNMZ6Zszz+S2yTlJStCpnaMSnQg==",
+            "requires": {
+                "@supabase/auth-js": "2.110.2",
+                "@supabase/functions-js": "2.110.2",
+                "@supabase/postgrest-js": "2.110.2",
+                "@supabase/realtime-js": "2.110.2",
+                "@supabase/storage-js": "2.110.2"
+            }
+        },
         "@swc/helpers": {
             "version": "0.4.37",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.37.tgz",
@@ -27574,6 +27792,11 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+        },
+        "iceberg-js": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+            "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
         },
         "iconv-lite": {
             "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "typecheck": "tsc --noEmit",
         "digest": "node scripts/digest/run.mjs",
         "storybook": "storybook dev -p 6006",
-        "build-storybook": "storybook build"
+        "build-storybook": "storybook build",
+        "migrate": "set -a && source .env.development && set +a && supabase db push --yes"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
@@ -23,6 +24,7 @@
         "@chakra-ui/react": "^2.10.6",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@supabase/supabase-js": "^2.110.2",
         "framer-motion": "^12.4.10",
         "gatsby": "^5.14.1",
         "react": "^18.2.0",

--- a/src/components/AuthButton/AuthButton.tsx
+++ b/src/components/AuthButton/AuthButton.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+    Avatar,
+    Menu,
+    MenuButton,
+    MenuItem,
+    MenuList,
+    Button,
+    Skeleton,
+} from '@chakra-ui/react';
+import { useAuth } from '../../contexts/AuthContext';
+
+export const AuthButton: React.FC = () => {
+    const { user, loading, signInWithGitHub, signOut } = useAuth();
+
+    if (loading) return <Skeleton w={8} h={8} borderRadius='full' />;
+
+    if (!user) {
+        return (
+            <Button
+                size='sm'
+                variant='outline'
+                colorScheme='green'
+                onClick={signInWithGitHub}
+                flexShrink={0}
+                fontSize={{ base: 'xs', md: 'sm' }}
+            >
+                ログイン
+            </Button>
+        );
+    }
+
+    return (
+        <Menu>
+            <MenuButton flexShrink={0}>
+                <Avatar
+                    size='sm'
+                    name={user.user_metadata?.full_name ?? user.email}
+                    src={user.user_metadata?.avatar_url}
+                    bg='brand.700'
+                    color='white'
+                />
+            </MenuButton>
+            <MenuList fontSize='sm' minW='120px'>
+                <MenuItem onClick={signOut} color='red.500'>
+                    ログアウト
+                </MenuItem>
+            </MenuList>
+        </Menu>
+    );
+};

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import { Box, Button, Flex, HStack, Text } from '@chakra-ui/react';
+import { AuthButton } from '../AuthButton/AuthButton';
 
 type NavTab = { label: string; to: string };
 
@@ -81,21 +82,7 @@ export const NavBar: React.FC<Props> = ({ activePath = '/' }) => {
                     </HStack>
                 </Box>
 
-                {/* アバター */}
-                <Flex
-                    w={8}
-                    h={8}
-                    borderRadius='full'
-                    bg='brand.700'
-                    color='white'
-                    align='center'
-                    justify='center'
-                    fontSize='xs'
-                    fontWeight='bold'
-                    flexShrink={0}
-                >
-                    YY
-                </Flex>
+                <AuthButton />
             </Flex>
         </Box>
     );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+type AuthContextValue = {
+    user: User | null;
+    loading: boolean;
+    signInWithGitHub: () => Promise<void>;
+    signOut: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue>({
+    user: null,
+    loading: true,
+    signInWithGitHub: async () => {},
+    signOut: async () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [user, setUser] = useState<User | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        supabase.auth.getSession().then(({ data: { session } }) => {
+            setUser(session?.user ?? null);
+            setLoading(false);
+        });
+
+        const {
+            data: { subscription },
+        } = supabase.auth.onAuthStateChange((_, session) => {
+            setUser(session?.user ?? null);
+            setLoading(false);
+        });
+
+        return () => subscription.unsubscribe();
+    }, []);
+
+    const signInWithGitHub = useCallback(async () => {
+        const redirectTo =
+            typeof window !== 'undefined'
+                ? `${window.location.origin}/auth/callback/`
+                : undefined;
+        await supabase.auth.signInWithOAuth({
+            provider: 'github',
+            options: { redirectTo },
+        });
+    }, []);
+
+    const signOut = useCallback(async () => {
+        await supabase.auth.signOut();
+    }, []);
+
+    return (
+        <AuthContext.Provider value={{ user, loading, signInWithGitHub, signOut }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/hooks/useReadState.ts
+++ b/src/hooks/useReadState.ts
@@ -1,50 +1,17 @@
 import { useCallback } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 
-export type SavedArticle = {
-    title: string;
-    link: string;
-    source: string;
-    publishedAt?: string | null;
-    hatebu?: number;
-    summary?: string;
-    matchedKeywords?: string[];
-    savedAt: string;
-};
-
 export function useReadState() {
     const [readLinks, setReadLinks] = useLocalStorage<string[]>('mizuo:read', []);
-    const [savedArticles, setSavedArticles] = useLocalStorage<SavedArticle[]>('mizuo:saved', []);
 
     const markRead = useCallback(
         (link: string) => {
-            setReadLinks((prev) =>
-                prev.includes(link) ? prev : [...prev, link]
-            );
+            setReadLinks((prev) => (prev.includes(link) ? prev : [...prev, link]));
         },
-        [setReadLinks]
+        [setReadLinks],
     );
 
-    const toggleSaved = useCallback(
-        (article: SavedArticle) => {
-            setSavedArticles((prev) => {
-                const exists = prev.some((a) => a.link === article.link);
-                if (exists) return prev.filter((a) => a.link !== article.link);
-                return [{ ...article, savedAt: new Date().toISOString() }, ...prev];
-            });
-        },
-        [setSavedArticles]
-    );
+    const isRead = useCallback((link: string) => readLinks.includes(link), [readLinks]);
 
-    const isRead = useCallback(
-        (link: string) => readLinks.includes(link),
-        [readLinks]
-    );
-
-    const isSaved = useCallback(
-        (link: string) => savedArticles.some((a) => a.link === link),
-        [savedArticles]
-    );
-
-    return { markRead, toggleSaved, isRead, isSaved, savedArticles };
+    return { markRead, isRead };
 }

--- a/src/hooks/useSavedArticles.ts
+++ b/src/hooks/useSavedArticles.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { supabase } from '../lib/supabase';
+import { useLocalStorage } from './useLocalStorage';
+
+export type SavedArticle = {
+    title: string;
+    link: string;
+    source: string;
+    publishedAt?: string | null;
+    hatebu?: number;
+    summary?: string;
+    matchedKeywords?: string[];
+    savedAt: string;
+};
+
+type DbRow = {
+    id: string;
+    user_id: string;
+    title: string;
+    link: string;
+    source: string;
+    published_at: string | null;
+    hatebu: number | null;
+    summary: string | null;
+    matched_keywords: string[] | null;
+    saved_at: string;
+};
+
+function fromDb(row: DbRow): SavedArticle {
+    return {
+        title: row.title,
+        link: row.link,
+        source: row.source,
+        publishedAt: row.published_at,
+        hatebu: row.hatebu ?? undefined,
+        summary: row.summary ?? undefined,
+        matchedKeywords: row.matched_keywords ?? undefined,
+        savedAt: row.saved_at,
+    };
+}
+
+function toDb(article: SavedArticle, userId: string) {
+    return {
+        user_id: userId,
+        title: article.title,
+        link: article.link,
+        source: article.source,
+        published_at: article.publishedAt ?? null,
+        hatebu: article.hatebu ?? null,
+        summary: article.summary ?? null,
+        matched_keywords: article.matchedKeywords ?? null,
+        saved_at: article.savedAt || new Date().toISOString(),
+    };
+}
+
+export function useSavedArticles() {
+    const { user } = useAuth();
+    const [localSaved, setLocalSaved] = useLocalStorage<SavedArticle[]>('mizuo:saved', []);
+    const [remoteSaved, setRemoteSaved] = useState<SavedArticle[]>([]);
+    const migrated = useRef(false);
+
+    useEffect(() => {
+        if (!user) {
+            setRemoteSaved([]);
+            return;
+        }
+        supabase
+            .from('saved_articles')
+            .select('*')
+            .order('saved_at', { ascending: false })
+            .then(({ data }) => {
+                if (data) setRemoteSaved((data as DbRow[]).map(fromDb));
+            });
+    }, [user]);
+
+    // ログイン後にlocalStorageのデータをSupabaseへ1回だけ移行
+    useEffect(() => {
+        if (!user || localSaved.length === 0 || migrated.current) return;
+        migrated.current = true;
+        const rows = localSaved.map((a) => toDb(a, user.id));
+        supabase
+            .from('saved_articles')
+            .upsert(rows, { onConflict: 'user_id,link' })
+            .then(({ error }) => {
+                if (!error) {
+                    setLocalSaved([]);
+                    supabase
+                        .from('saved_articles')
+                        .select('*')
+                        .order('saved_at', { ascending: false })
+                        .then(({ data }) => {
+                            if (data) setRemoteSaved((data as DbRow[]).map(fromDb));
+                        });
+                }
+            });
+    }, [user, localSaved, setLocalSaved]);
+
+    const savedArticles = user ? remoteSaved : localSaved;
+
+    const toggleSaved = useCallback(
+        async (article: SavedArticle) => {
+            if (!user) {
+                setLocalSaved((prev) => {
+                    const exists = prev.some((a) => a.link === article.link);
+                    if (exists) return prev.filter((a) => a.link !== article.link);
+                    return [{ ...article, savedAt: new Date().toISOString() }, ...prev];
+                });
+                return;
+            }
+
+            const exists = remoteSaved.some((a) => a.link === article.link);
+            if (exists) {
+                setRemoteSaved((prev) => prev.filter((a) => a.link !== article.link));
+                await supabase
+                    .from('saved_articles')
+                    .delete()
+                    .match({ user_id: user.id, link: article.link });
+            } else {
+                const newArticle = { ...article, savedAt: new Date().toISOString() };
+                setRemoteSaved((prev) => [newArticle, ...prev]);
+                await supabase.from('saved_articles').insert(toDb(newArticle, user.id));
+            }
+        },
+        [user, remoteSaved, setLocalSaved],
+    );
+
+    const isSaved = useCallback(
+        (link: string) => savedArticles.some((a) => a.link === link),
+        [savedArticles],
+    );
+
+    return { savedArticles, toggleSaved, isSaved };
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.GATSBY_SUPABASE_URL ?? '';
+const key = process.env.GATSBY_SUPABASE_ANON_KEY ?? '';
+
+export const supabase = createClient(url, key);

--- a/src/pages/auth/callback.tsx
+++ b/src/pages/auth/callback.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { navigate } from 'gatsby';
+import { Box, Spinner, Text } from '@chakra-ui/react';
+import { supabase } from '../../lib/supabase';
+
+const AuthCallbackPage: React.FC = () => {
+    useEffect(() => {
+        // SupabaseがURLフラグメントからセッションを自動検出する
+        supabase.auth.getSession().then(() => {
+            navigate('/', { replace: true });
+        });
+    }, []);
+
+    return (
+        <Box
+            minH='100vh'
+            display='flex'
+            flexDirection='column'
+            alignItems='center'
+            justifyContent='center'
+            gap={4}
+            bg='neutral.bg'
+        >
+            <Spinner size='lg' color='brand.700' />
+            <Text fontSize='sm' color='neutral.textSecondary'>
+                認証中...
+            </Text>
+        </Box>
+    );
+};
+
+export default AuthCallbackPage;

--- a/src/pages/digest.tsx
+++ b/src/pages/digest.tsx
@@ -5,6 +5,7 @@ import { Box, Text } from '@chakra-ui/react';
 import { ArticleCard } from '../components/ArticleCard/ArticleCard';
 import { EmptyState } from '../components/EmptyState/EmptyState';
 import { useReadState } from '../hooks/useReadState';
+import { useSavedArticles } from '../hooks/useSavedArticles';
 
 type DigestItem = {
     title: string;
@@ -23,7 +24,8 @@ type DigestDay = {
 
 const DigestPage: React.FC = () => {
     const days = digests as DigestDay[];
-    const { markRead, toggleSaved, isRead, isSaved } = useReadState();
+    const { markRead, isRead } = useReadState();
+    const { toggleSaved, isSaved } = useSavedArticles();
 
     return (
         <Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import { HeroCard } from '../components/HeroCard/HeroCard';
 import { ArticleCard } from '../components/ArticleCard/ArticleCard';
 import { EmptyState } from '../components/EmptyState/EmptyState';
 import { useReadState } from '../hooks/useReadState';
+import { useSavedArticles } from '../hooks/useSavedArticles';
 import digestConfig from '../utils/digestConfig';
 
 type BlogPost = {
@@ -27,14 +28,15 @@ const TOPICS = [...digestConfig.keywords];
 
 const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
     const [activeTopic, setActiveTopic] = useState('すべて');
-    const { markRead, toggleSaved, isRead, isSaved } = useReadState();
+    const { markRead, isRead } = useReadState();
+    const { toggleSaved, isSaved } = useSavedArticles();
 
     const posts = data.allBlogPost.nodes;
 
     const filtered = useMemo(() => {
         if (activeTopic === 'すべて') return posts;
         return posts.filter((p) =>
-            `${p.title} ${p.sourceTitle}`.toLowerCase().includes(activeTopic.toLowerCase())
+            `${p.title} ${p.sourceTitle}`.toLowerCase().includes(activeTopic.toLowerCase()),
         );
     }, [posts, activeTopic]);
 
@@ -46,7 +48,7 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
         title: p.title,
         link: p.link,
         matchedKeywords: TOPICS.filter((kw) =>
-            p.title.toLowerCase().includes(kw.toLowerCase())
+            p.title.toLowerCase().includes(kw.toLowerCase()),
         ),
     }));
 
@@ -82,7 +84,7 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
                                 source: hero.sourceTitle,
                                 publishedAt: hero.pubDate,
                                 matchedKeywords: TOPICS.filter((kw) =>
-                                    hero.title.toLowerCase().includes(kw.toLowerCase())
+                                    hero.title.toLowerCase().includes(kw.toLowerCase()),
                                 ),
                                 savedAt: '',
                             })
@@ -94,7 +96,7 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
             <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
                 {rest.slice(4).map((post) => {
                     const matchedKeywords = TOPICS.filter((kw) =>
-                        post.title.toLowerCase().includes(kw.toLowerCase())
+                        post.title.toLowerCase().includes(kw.toLowerCase()),
                     );
                     return (
                         <ArticleCard

--- a/src/pages/saved.tsx
+++ b/src/pages/saved.tsx
@@ -3,13 +3,17 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import Layout from '../components/layout';
 import { ArticleCard } from '../components/ArticleCard/ArticleCard';
 import { EmptyState } from '../components/EmptyState/EmptyState';
-import { useReadState, type SavedArticle } from '../hooks/useReadState';
+import { useSavedArticles, type SavedArticle } from '../hooks/useSavedArticles';
+import { useReadState } from '../hooks/useReadState';
 
 const SavedPage: React.FC = () => {
-    const { savedArticles, toggleSaved, isRead, markRead } = useReadState();
+    const { savedArticles, toggleSaved } = useSavedArticles();
+    const { isRead, markRead } = useReadState();
     // SSRと一致させるため、ハイドレーション後に描画する
     const [mounted, setMounted] = useState(false);
-    useEffect(() => { setMounted(true); }, []);
+    useEffect(() => {
+        setMounted(true);
+    }, []);
 
     if (!mounted) return <Layout><Box /></Layout>;
 

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "tech-blog-aggregator"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260711000000_create_saved_articles.sql
+++ b/supabase/migrations/20260711000000_create_saved_articles.sql
@@ -1,0 +1,24 @@
+create table public.saved_articles (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+  title text not null,
+  link text not null,
+  source text not null,
+  published_at timestamptz,
+  hatebu integer,
+  summary text,
+  matched_keywords text[],
+  saved_at timestamptz default now() not null,
+  unique(user_id, link)
+);
+
+alter table public.saved_articles enable row level security;
+
+create policy "自分の保存記事のみ参照可"
+  on public.saved_articles for select using (auth.uid() = user_id);
+
+create policy "自分の保存記事のみ挿入可"
+  on public.saved_articles for insert with check (auth.uid() = user_id);
+
+create policy "自分の保存記事のみ削除可"
+  on public.saved_articles for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

- Supabase + GitHub OAuthによるユーザー認証を実装
- ログイン中は保存記事をSupabase DBに永続化（デバイス間で同期）
- 未ログイン時はlocalStorageにフォールバック、ログイン時に自動マイグレーション
- NavBarにAuthButton（ログイン/ログアウト）を追加
- `supabase/migrations/` にDDLを管理し、mainマージ時にCIで自動適用

## 変更ファイル

- `src/lib/supabase.ts` — Supabaseクライアント
- `src/contexts/AuthContext.tsx` — 認証状態のReact Context
- `src/hooks/useSavedArticles.ts` — Supabase/localStorage切り替えフック
- `src/components/AuthButton/AuthButton.tsx` — ログインUI
- `src/pages/auth/callback.tsx` — OAuthコールバックページ
- `gatsby-browser.tsx` / `gatsby-ssr.tsx` — AuthProviderをルートに注入
- `.github/workflows/migrate.yml` — mainマージ時の自動マイグレーション

## 必要な環境変数（Netlify）

```
GATSBY_SUPABASE_URL
GATSBY_SUPABASE_ANON_KEY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9pFdJSDgEGi2mK1TSgnVv