### PR TITLE
feat: 保存済み機能とMizuoデザインシステムの適用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .cache/
+.netlify/
 public
 src/gatsby-types.d.ts
 .env*

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
+/>

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -1,6 +1,25 @@
 import React from 'react';
+import type { RenderBodyArgs } from 'gatsby';
 import { AuthProvider } from './src/contexts/AuthContext';
 
 export const wrapRootElement = ({ element }: { element: React.ReactNode }) => (
     <AuthProvider>{element}</AuthProvider>
 );
+
+// Mizuoデザインシステムの唯一のフォント Noto Sans JP を読み込む
+export const onRenderBody = ({ setHeadComponents }: RenderBodyArgs) => {
+    setHeadComponents([
+        <link key='gf-preconnect' rel='preconnect' href='https://fonts.googleapis.com' />,
+        <link
+            key='gf-preconnect-static'
+            rel='preconnect'
+            href='https://fonts.gstatic.com'
+            crossOrigin='anonymous'
+        />,
+        <link
+            key='gf-noto-sans-jp'
+            rel='stylesheet'
+            href='https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap'
+        />,
+    ]);
+};

--- a/src/@chakra-ui/gatsby-plugin/theme.ts
+++ b/src/@chakra-ui/gatsby-plugin/theme.ts
@@ -1,0 +1,5 @@
+// @chakra-ui/gatsby-plugin のテーマシャドウイング
+// ここで default export したテーマがサイト全体の ChakraProvider に渡される
+import { mizuoTheme } from '../../theme/mizuo';
+
+export default mizuoTheme;

--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge, Box, Flex, IconButton, Link, Text } from '@chakra-ui/react';
+import { Badge, Flex, IconButton, Link, Text } from '@chakra-ui/react';
 
 type Props = {
     title: string;
@@ -27,6 +27,7 @@ function relativeTime(date: Date): string {
     return `${days}日前`;
 }
 
+// 標準の記事カード（白サーフェス）: ソース行 → タイトル → トピックタグ
 export const ArticleCard: React.FC<Props> = ({
     title,
     link,
@@ -42,63 +43,75 @@ export const ArticleCard: React.FC<Props> = ({
     onSave,
 }) => {
     return (
-        <Box
-            bg='white'
-            borderRadius='xl'
-            p={4}
+        <Flex
+            as='article'
+            direction='column'
+            gap='0.625rem'
+            bg='neutral.surface'
+            borderRadius='card'
+            p={5}
+            shadow='card'
             opacity={isRead ? 0.5 : 1}
-            transition='opacity 0.2s'
-            _hover={{ shadow: 'sm' }}
-            position='relative'
+            transition='opacity 0.2s ease, box-shadow 0.15s ease'
+            _hover={{ shadow: 'raised' }}
         >
-            <Flex justify='space-between' align='flex-start' gap={2}>
-                <Box flex={1}>
-                    <Text fontSize='xs' color='neutral.textMuted' mb={1} noOfLines={1}>
-                        {source}
-                        {publishedAt && ` · ${relativeTime(publishedAt)}`}
-                        {hatebu > 0 && ` · 🔖${hatebu}`}
+            <Flex align='center' gap={2} fontSize='sm' color='neutral.textMuted'>
+                <Text as='span' noOfLines={1}>
+                    {source}
+                </Text>
+                {hatebu > 0 && (
+                    <Text as='span' flexShrink={0}>
+                        はてブ {hatebu}
                     </Text>
-                    <Link
-                        href={link}
-                        isExternal
-                        fontWeight='semibold'
-                        fontSize='sm'
-                        color='neutral.textPrimary'
-                        onClick={onRead}
-                        _hover={{ color: 'brand.600' }}
-                    >
-                        {title}
-                    </Link>
-                    {summary && (
-                        <Text mt={1} fontSize='xs' color='neutral.textSecondary' noOfLines={2}>
-                            {summary}
-                        </Text>
-                    )}
-                    {(matchedKeywords.length > 0 || serendipity) && (
-                        <Flex mt={2} gap={1} flexWrap='wrap'>
-                            {matchedKeywords.map((kw) => (
-                                <Badge key={kw} colorScheme='blue' variant='subtle'>
-                                    {kw}
-                                </Badge>
-                            ))}
-                            {serendipity && (
-                                <Badge colorScheme='purple' variant='subtle'>
-                                    🎲
-                                </Badge>
-                            )}
-                        </Flex>
-                    )}
-                </Box>
+                )}
+                {publishedAt && (
+                    <Text as='span' flexShrink={0}>
+                        {relativeTime(publishedAt)}
+                    </Text>
+                )}
                 <IconButton
                     aria-label={isSaved ? '保存済み' : '保存'}
                     icon={<span>{isSaved ? '★' : '☆'}</span>}
                     size='xs'
                     variant='ghost'
-                    color={isSaved ? 'yellow.400' : 'neutral.textMuted'}
+                    fontSize='15px'
+                    minW='auto'
+                    h='auto'
+                    ml='auto'
+                    color={isSaved ? 'highlight.base' : 'neutral.textMuted'}
+                    _hover={{ bg: 'transparent', color: 'highlight.base' }}
                     onClick={onSave}
                     flexShrink={0}
                 />
             </Flex>
-        </Box>
+            <Link
+                href={link}
+                isExternal
+                fontWeight='bold'
+                fontSize='md'
+                lineHeight={1.6}
+                flex={1}
+                color='neutral.textPrimary'
+                onClick={onRead}
+                _hover={{ color: 'accent.base', textDecoration: 'none' }}
+            >
+                {title}
+            </Link>
+            {summary && (
+                <Text fontSize='sm' color='neutral.textSecondary' lineHeight={1.8} noOfLines={2}>
+                    {summary}
+                </Text>
+            )}
+            {(matchedKeywords.length > 0 || serendipity) && (
+                <Flex gap='0.375rem' flexWrap='wrap'>
+                    {matchedKeywords.map((kw) => (
+                        <Badge key={kw} variant='accent'>
+                            {kw}
+                        </Badge>
+                    ))}
+                    {serendipity && <Badge variant='amber'>寄り道</Badge>}
+                </Flex>
+            )}
+        </Flex>
     );
 };

--- a/src/components/AuthButton/AuthButton.tsx
+++ b/src/components/AuthButton/AuthButton.tsx
@@ -20,7 +20,7 @@ export const AuthButton: React.FC = () => {
             <Button
                 size='sm'
                 variant='outline'
-                colorScheme='green'
+                colorScheme='brand'
                 onClick={signInWithGitHub}
                 flexShrink={0}
                 fontSize={{ base: 'xs', md: 'sm' }}

--- a/src/components/GreetingHeader/GreetingHeader.stories.tsx
+++ b/src/components/GreetingHeader/GreetingHeader.stories.tsx
@@ -7,5 +7,5 @@ const meta: Meta<typeof GreetingHeader> = {
 };
 export default meta;
 
-export const Default: StoryObj = { args: { unreadCount: 7 } };
-export const NoUnread: StoryObj = { args: { unreadCount: 0 } };
+export const Default: StoryObj = { args: { unreadCount: 7, totalCount: 12 } };
+export const NoUnread: StoryObj = { args: { unreadCount: 0, totalCount: 12 } };

--- a/src/components/GreetingHeader/GreetingHeader.tsx
+++ b/src/components/GreetingHeader/GreetingHeader.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Box, Text } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 
 type Props = {
     unreadCount: number;
+    totalCount?: number;
     date?: Date;
 };
 
@@ -10,21 +11,27 @@ const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
 
 export const GreetingHeader: React.FC<Props> = ({
     unreadCount,
+    totalCount,
     date = new Date(),
 }) => {
     const month = date.getMonth() + 1;
     const day = date.getDate();
     const weekday = WEEKDAYS[date.getDay()];
 
+    const meta = [
+        `${month}月${day}日(${weekday})`,
+        ...(totalCount != null ? [`あなた向けに${totalCount}本`] : []),
+        `未読${unreadCount}本`,
+    ].join(' ・ ');
+
     return (
-        <Box mb={4}>
-            <Text fontWeight='bold' fontSize={{ base: '2xl', md: '3xl' }} color='neutral.textPrimary'>
+        <Flex align={{ base: 'flex-start', md: 'flex-end' }} direction={{ base: 'column', md: 'row' }} gap={{ base: 1, md: '18px' }} mb='6px'>
+            <Text as='h1' fontWeight='bold' fontSize='3xl' color='neutral.textPrimary' lineHeight={1.3}>
                 おはようございます
             </Text>
-            <Text fontSize='sm' color='neutral.textSecondary' mt={1}>
-                {month}月{day}日({weekday})
-                {unreadCount > 0 && ` · あなた向けに${unreadCount}本 · 未読${unreadCount}本`}
+            <Text fontSize='sm' color='neutral.textSecondary' pb={{ base: 0, md: '4px' }}>
+                {meta}
             </Text>
-        </Box>
+        </Flex>
     );
 };

--- a/src/components/HeroCard/HeroCard.stories.tsx
+++ b/src/components/HeroCard/HeroCard.stories.tsx
@@ -7,13 +7,6 @@ const meta: Meta<typeof HeroCard> = {
 };
 export default meta;
 
-const sideItems = [
-    { rank: 1, title: 'DeNAの南場智子会長が行っているAI活用方法', link: '#', matchedKeywords: ['AI'] },
-    { rank: 2, title: 'ソフトウェア設計における抽象とメタの違い', link: '#', matchedKeywords: ['設計'] },
-    { rank: 3, title: 'IAMユーザーを持っていないメンバーとのS3共有', link: '#', matchedKeywords: [] },
-    { rank: 4, title: 'わずか5MBのAIモデルをウェブサイトに組み込む', link: '#', matchedKeywords: ['AI'] },
-];
-
 export const Default: StoryObj = {
     args: {
         title: 'APIもDBも東京なのに、全クエリが太平洋横断していた話',
@@ -22,10 +15,9 @@ export const Default: StoryObj = {
         publishedAt: new Date(Date.now() - 3 * 3600000),
         hatebu: 147,
         snippet: 'AI旅行アプリのフルリニューアル直後から「ほぼ全てのAPIが遅い」という報告が。調査すると東京のAPIが太平洋を横断してデータを取得していた。',
-        sideItems,
     },
 };
 
-export const NoSidebar: StoryObj = {
-    args: { ...Default.args, sideItems: [] },
+export const Saved: StoryObj = {
+    args: { ...Default.args, isSaved: true },
 };

--- a/src/components/HeroCard/HeroCard.tsx
+++ b/src/components/HeroCard/HeroCard.tsx
@@ -1,21 +1,5 @@
 import React from 'react';
-import {
-    Badge,
-    Box,
-    Flex,
-    Grid,
-    GridItem,
-    IconButton,
-    Link,
-    Text,
-} from '@chakra-ui/react';
-
-type SideItem = {
-    rank: number;
-    title: string;
-    link: string;
-    matchedKeywords?: string[];
-};
+import { Badge, Flex, IconButton, Link, Text } from '@chakra-ui/react';
 
 type Props = {
     title: string;
@@ -24,12 +8,12 @@ type Props = {
     publishedAt?: Date | null;
     hatebu?: number;
     snippet?: string;
-    sideItems?: SideItem[];
     isSaved?: boolean;
     onRead?: () => void;
     onSave?: () => void;
 };
 
+// イチオシのヒーローカード（teal surface, white text）
 export const HeroCard: React.FC<Props> = ({
     title,
     link,
@@ -37,7 +21,6 @@ export const HeroCard: React.FC<Props> = ({
     publishedAt,
     hatebu = 0,
     snippet,
-    sideItems = [],
     isSaved = false,
     onRead,
     onSave,
@@ -52,109 +35,58 @@ export const HeroCard: React.FC<Props> = ({
         : '';
 
     return (
-        <Grid
-            templateColumns={{ base: '1fr', md: '1fr 280px' }}
+        <Flex
+            as='article'
+            direction='column'
             bg='hero.bg'
-            borderRadius='2xl'
-            overflow='hidden'
-            minH='200px'
+            color='hero.text'
+            borderRadius='card'
+            p={6}
+            shadow='card'
+            transition='box-shadow 0.15s ease'
+            _hover={{ shadow: 'raised' }}
         >
-            {/* メイン記事 */}
-            <GridItem p={6}>
-                <Flex justify='space-between' align='flex-start'>
-                    <Badge bg='hero.badge' color='white' mb={3}>
-                        イチオシ
-                    </Badge>
-                    <IconButton
-                        aria-label={isSaved ? '保存済み' : '保存'}
-                        icon={<span>{isSaved ? '★' : '☆'}</span>}
-                        size='xs'
-                        variant='ghost'
-                        color={isSaved ? 'yellow.300' : 'hero.muted'}
-                        onClick={onSave}
-                    />
-                </Flex>
-                <Link
-                    href={link}
-                    isExternal
-                    color='hero.text'
-                    fontWeight='bold'
-                    fontSize={{ base: 'lg', md: 'xl' }}
-                    lineHeight='short'
-                    display='block'
-                    mb={3}
-                    onClick={onRead}
-                    _hover={{ color: 'hero.muted', textDecoration: 'none' }}
-                >
-                    {title}
-                </Link>
-                {snippet && (
-                    <Text color='hero.muted' fontSize='sm' noOfLines={3} mb={3}>
-                        {snippet}
-                    </Text>
-                )}
-                <Text color='hero.muted' fontSize='xs'>
-                    {source}
-                    {hatebu > 0 && ` · 🔖${hatebu}`}
-                    {timeStr && ` · ${timeStr}`}
+            <Flex align='flex-start'>
+                <Badge bg='hero.badgeBg' color='hero.badgeText'>
+                    イチオシ
+                </Badge>
+                <IconButton
+                    aria-label={isSaved ? '保存済み' : '保存'}
+                    icon={<span>{isSaved ? '★' : '☆'}</span>}
+                    size='xs'
+                    variant='ghost'
+                    fontSize='15px'
+                    ml='auto'
+                    color={isSaved ? 'highlight.base' : 'hero.star'}
+                    _hover={{ bg: 'whiteAlpha.200' }}
+                    onClick={onSave}
+                />
+            </Flex>
+            <Link
+                href={link}
+                isExternal
+                color='hero.text'
+                fontWeight='bold'
+                fontSize='2xl'
+                lineHeight={1.5}
+                display='block'
+                mt='0.81rem'
+                mb='0.56rem'
+                onClick={onRead}
+                _hover={{ color: 'hero.summary', textDecoration: 'none' }}
+            >
+                {title}
+            </Link>
+            {snippet && (
+                <Text color='hero.summary' fontSize='md' lineHeight={1.8} flex={1} noOfLines={3}>
+                    {snippet}
                 </Text>
-            </GridItem>
-
-            {/* 続けて読む */}
-            {sideItems.length > 0 && (
-                <GridItem
-                    bg='rgba(255,255,255,0.06)'
-                    p={5}
-                    borderLeftWidth={{ base: 0, md: '1px' }}
-                    borderTopWidth={{ base: '1px', md: 0 }}
-                    borderColor='rgba(255,255,255,0.12)'
-                >
-                    <Text color='hero.muted' fontSize='xs' fontWeight='semibold' mb={3}>
-                        続けて読む
-                    </Text>
-                    <Flex direction='column' gap={3}>
-                        {sideItems.slice(0, 4).map((item) => (
-                            <Flex key={item.link} gap={3} align='flex-start'>
-                                <Text
-                                    color='hero.number'
-                                    fontWeight='bold'
-                                    fontSize='xs'
-                                    flexShrink={0}
-                                    pt='1px'
-                                >
-                                    {String(item.rank).padStart(2, '0')}
-                                </Text>
-                                <Box>
-                                    <Link
-                                        href={item.link}
-                                        isExternal
-                                        color='hero.text'
-                                        fontSize='xs'
-                                        fontWeight='medium'
-                                        _hover={{ color: 'hero.muted', textDecoration: 'none' }}
-                                    >
-                                        {item.title}
-                                    </Link>
-                                    {(item.matchedKeywords ?? []).length > 0 && (
-                                        <Flex mt={1} gap={1}>
-                                            {item.matchedKeywords!.map((kw) => (
-                                                <Badge
-                                                    key={kw}
-                                                    bg='rgba(255,255,255,0.1)'
-                                                    color='hero.muted'
-                                                    fontSize='2xs'
-                                                >
-                                                    {kw}
-                                                </Badge>
-                                            ))}
-                                        </Flex>
-                                    )}
-                                </Box>
-                            </Flex>
-                        ))}
-                    </Flex>
-                </GridItem>
             )}
-        </Grid>
+            <Flex gap='0.875rem' fontSize='sm' color='hero.muted' mt={4}>
+                <Text as='span'>{source}</Text>
+                {hatebu > 0 && <Text as='span'>はてブ {hatebu}</Text>}
+                {timeStr && <Text as='span'>{timeStr}</Text>}
+            </Flex>
+        </Flex>
     );
 };

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -20,23 +20,24 @@ export const NavBar: React.FC<Props> = ({ activePath = '/' }) => {
     return (
         <Box
             as='header'
-            bg='white'
+            bg='neutral.surface'
             borderBottomWidth='1px'
             borderColor='neutral.border'
-            px={{ base: 3, md: 6 }}
+            px={{ base: 3, md: 9 }}
             py={3}
             position='sticky'
             top={0}
             zIndex='sticky'
         >
-            <Flex align='center' maxW='container.lg' mx='auto' gap={{ base: 2, md: 4 }}>
-                {/* ロゴ: モバイルでは非表示 */}
+            <Flex align='center' maxW='70rem' mx='auto' gap={{ base: 2, md: '1.375rem' }}>
+                {/* ワードマーク: モバイルでは非表示 */}
                 <Text
                     as={Link}
                     to='/'
                     fontWeight='bold'
-                    fontSize='lg'
-                    color='neutral.textPrimary'
+                    fontSize='xl'
+                    letterSpacing='0.02em'
+                    color='accent.base'
                     flexShrink={0}
                     display={{ base: 'none', md: 'block' }}
                     _hover={{ textDecoration: 'none' }}
@@ -44,17 +45,14 @@ export const NavBar: React.FC<Props> = ({ activePath = '/' }) => {
                     Mizuo
                 </Text>
 
-                {/* タブナビ: モバイルでは横スクロール */}
+                {/* ピルナビ: モバイルでは横スクロール */}
                 <Box
                     overflowX='auto'
                     flex={1}
                     sx={{ '&::-webkit-scrollbar': { display: 'none' }, scrollbarWidth: 'none' }}
                 >
                     <HStack
-                        spacing={1}
-                        bg='neutral.chip'
-                        borderRadius='full'
-                        p={1}
+                        spacing='0.375rem'
                         width='fit-content'
                         minW='100%'
                         justifyContent={{ base: 'space-between', md: 'flex-start' }}
@@ -66,13 +64,12 @@ export const NavBar: React.FC<Props> = ({ activePath = '/' }) => {
                                     key={tab.to}
                                     as={Link}
                                     to={tab.to}
-                                    variant='tab'
+                                    variant='navTab'
                                     aria-current={isActive ? 'page' : undefined}
-                                    bg={isActive ? 'white' : 'transparent'}
-                                    color={isActive ? 'neutral.textPrimary' : 'neutral.textSecondary'}
-                                    shadow={isActive ? 'sm' : 'none'}
-                                    fontSize={{ base: 'xs', md: 'sm' }}
-                                    px={{ base: 3, md: 4 }}
+                                    bg={isActive ? 'accent.soft' : 'transparent'}
+                                    color={isActive ? 'accent.base' : 'neutral.textSecondary'}
+                                    fontSize={{ base: 'sm', md: 'md' }}
+                                    px={{ base: 3, md: '0.875rem' }}
                                     flexShrink={0}
                                 >
                                     {tab.label}

--- a/src/components/ReadingList/ReadingList.stories.tsx
+++ b/src/components/ReadingList/ReadingList.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ReadingList } from './ReadingList';
+
+const meta: Meta<typeof ReadingList> = {
+    title: 'Mizuo/ReadingList',
+    component: ReadingList,
+};
+export default meta;
+
+export const Default: StoryObj = {
+    args: {
+        items: [
+            { index: 2, title: 'DeNAの南場智子会長が行っているAI活用方法', link: '#' },
+            { index: 3, title: 'ソフトウェア設計における抽象とメタの違い', link: '#', isSaved: true },
+            { index: 4, title: 'IAMユーザーを持っていないメンバーとのS3共有', link: '#', isRead: true },
+            { index: 5, title: 'わずか5MBのAIモデルをウェブサイトに組み込む', link: '#' },
+        ],
+    },
+};

--- a/src/components/ReadingList/ReadingList.tsx
+++ b/src/components/ReadingList/ReadingList.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Box, Flex, IconButton, Link, Text } from '@chakra-ui/react';
+
+export type ReadingListItem = {
+    index: number;
+    title: string;
+    link: string;
+    isRead?: boolean;
+    isSaved?: boolean;
+    onRead?: () => void;
+    onSave?: () => void;
+};
+
+type Props = {
+    items: ReadingListItem[];
+};
+
+// 「続けて読む」白カード — アンバーの連番 + ヘアラインの区切り
+export const ReadingList: React.FC<Props> = ({ items }) => {
+    return (
+        <Box bg='neutral.surface' borderRadius='card' p='22px' shadow='card'>
+            <Text fontSize='sm' fontWeight='bold' color='neutral.textSecondary' mb={2}>
+                続けて読む
+            </Text>
+            {items.map((item, i) => (
+                <Flex
+                    key={item.link}
+                    gap={3}
+                    align='baseline'
+                    py='0.69rem'
+                    borderTopWidth={i === 0 ? 0 : '1px'}
+                    borderColor='neutral.border'
+                    opacity={item.isRead ? 0.45 : 1}
+                    transition='opacity 0.2s ease'
+                >
+                    <Text
+                        as='span'
+                        fontSize='xs'
+                        fontWeight='bold'
+                        color='highlight.base'
+                        minW='22px'
+                        flexShrink={0}
+                    >
+                        {String(item.index).padStart(2, '0')}
+                    </Text>
+                    <Link
+                        href={item.link}
+                        isExternal
+                        flex={1}
+                        fontSize='sm'
+                        fontWeight='medium'
+                        lineHeight={1.5}
+                        color='neutral.textPrimary'
+                        onClick={item.onRead}
+                        _hover={{ color: 'accent.base', textDecoration: 'none' }}
+                    >
+                        {item.title}
+                    </Link>
+                    <IconButton
+                        aria-label={item.isSaved ? '保存済み' : '保存'}
+                        icon={<span>{item.isSaved ? '★' : '☆'}</span>}
+                        size='xs'
+                        variant='ghost'
+                        fontSize='14px'
+                        minW='auto'
+                        h='auto'
+                        color={item.isSaved ? 'highlight.base' : 'neutral.textMuted'}
+                        _hover={{ bg: 'transparent', color: 'highlight.base' }}
+                        onClick={item.onSave}
+                        flexShrink={0}
+                    />
+                </Flex>
+            ))}
+        </Box>
+    );
+};

--- a/src/components/TopicChipBar/TopicChipBar.tsx
+++ b/src/components/TopicChipBar/TopicChipBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Flex } from '@chakra-ui/react';
+import { Button, Flex } from '@chakra-ui/react';
 
 type Props = {
     topics: string[];
@@ -9,7 +9,7 @@ type Props = {
 
 export const TopicChipBar: React.FC<Props> = ({ topics, active, onChange }) => {
     return (
-        <Flex gap={2} overflowX='auto' pb={1} sx={{ '&::-webkit-scrollbar': { display: 'none' } }}>
+        <Flex gap={2} overflowX='auto' pb={1} flexWrap={{ base: 'nowrap', md: 'wrap' }} sx={{ '&::-webkit-scrollbar': { display: 'none' } }}>
             {['すべて', ...topics].map((topic) => {
                 const isActive = active === topic;
                 return (
@@ -17,16 +17,18 @@ export const TopicChipBar: React.FC<Props> = ({ topics, active, onChange }) => {
                         key={topic}
                         variant='chip'
                         flexShrink={0}
-                        bg={isActive ? 'neutral.chipActive' : 'neutral.chip'}
-                        color={isActive ? 'white' : 'neutral.textSecondary'}
+                        bg={isActive ? 'accent.base' : 'neutral.surface'}
+                        borderColor={isActive ? 'accent.base' : 'neutral.border'}
+                        color={isActive ? 'white' : 'neutral.textPrimary'}
+                        _hover={isActive ? {} : { bg: 'accent.soft', borderColor: 'accent.soft' }}
                         onClick={() => onChange(topic)}
                     >
                         {topic}
                     </Button>
                 );
             })}
-            <Button variant='chip' flexShrink={0} color='neutral.textMuted'>
-                + トピックを追加
+            <Button variant='chipAdd' flexShrink={0}>
+                トピックを追加
             </Button>
         </Flex>
     );

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,7 +8,14 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     return (
         <Box minH='100vh' bg='neutral.bg' overflowX='hidden'>
             <NavBar activePath={location.pathname} />
-            <Box as='main' maxW='container.lg' mx='auto' px={{ base: 3, md: 4 }} py={6}>
+            <Box
+                as='main'
+                maxW='70rem'
+                mx='auto'
+                px={{ base: 3, md: 9 }}
+                pt='28px'
+                pb='56px'
+            >
                 {children}
             </Box>
         </Box>

--- a/src/pages/blogs.tsx
+++ b/src/pages/blogs.tsx
@@ -23,19 +23,20 @@ const BlogsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
                 {data.allBlogSource.nodes.map((source) => (
                     <Flex
                         key={source.name}
-                        bg='white'
-                        borderRadius='xl'
+                        bg='neutral.surface'
+                        borderRadius='card'
                         p={4}
                         align='center'
                         gap={3}
-                        _hover={{ shadow: 'sm' }}
-                        transition='box-shadow 0.15s'
+                        shadow='card'
+                        _hover={{ shadow: 'raised' }}
+                        transition='box-shadow 0.15s ease'
                     >
                         <Box
                             w={8}
                             h={8}
                             borderRadius='lg'
-                            bg='neutral.chip'
+                            bg='neutral.hover'
                             display='flex'
                             alignItems='center'
                             justifyContent='center'
@@ -50,7 +51,7 @@ const BlogsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
                             fontSize='sm'
                             fontWeight='medium'
                             color='neutral.textPrimary'
-                            _hover={{ color: 'brand.600', textDecoration: 'none' }}
+                            _hover={{ color: 'accent.base', textDecoration: 'none' }}
                             noOfLines={2}
                         >
                             {source.title}

--- a/src/pages/digest.tsx
+++ b/src/pages/digest.tsx
@@ -52,7 +52,7 @@ const DigestPage: React.FC = () => {
                         </Text>
                     )}
 
-                    <Box display='flex' flexDirection='column' gap={3}>
+                    <Box display='flex' flexDirection='column' gap={4}>
                         {day.items.map((item) => (
                             <ArticleCard
                                 key={item.link}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import { graphql, PageProps } from 'gatsby';
-import { Box, SimpleGrid } from '@chakra-ui/react';
+import { Box, Grid, SimpleGrid } from '@chakra-ui/react';
 import Layout from '../components/layout';
 import { GreetingHeader } from '../components/GreetingHeader/GreetingHeader';
 import { TopicChipBar } from '../components/TopicChipBar/TopicChipBar';
 import { HeroCard } from '../components/HeroCard/HeroCard';
+import { ReadingList } from '../components/ReadingList/ReadingList';
 import { ArticleCard } from '../components/ArticleCard/ArticleCard';
 import { EmptyState } from '../components/EmptyState/EmptyState';
 import { useReadState } from '../hooks/useReadState';
@@ -43,20 +44,33 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
     const unreadCount = filtered.filter((p) => !isRead(p.link)).length;
     const [hero, ...rest] = filtered;
 
-    const sideItems = rest.slice(0, 4).map((p, i) => ({
-        rank: i + 1,
+    const toSavedArticle = (post: BlogPost) => ({
+        title: post.title,
+        link: post.link,
+        source: post.sourceTitle,
+        publishedAt: post.pubDate,
+        matchedKeywords: TOPICS.filter((kw) =>
+            post.title.toLowerCase().includes(kw.toLowerCase()),
+        ),
+        savedAt: '',
+    });
+
+    // 「続けて読む」レール（イチオシが01なので02から連番）
+    const railItems = rest.slice(0, 4).map((p, i) => ({
+        index: i + 2,
         title: p.title,
         link: p.link,
-        matchedKeywords: TOPICS.filter((kw) =>
-            p.title.toLowerCase().includes(kw.toLowerCase()),
-        ),
+        isRead: isRead(p.link),
+        isSaved: isSaved(p.link),
+        onRead: () => markRead(p.link),
+        onSave: () => toggleSaved(toSavedArticle(p)),
     }));
 
     return (
         <Layout>
-            <GreetingHeader unreadCount={unreadCount} />
+            <GreetingHeader unreadCount={unreadCount} totalCount={filtered.length} />
 
-            <Box mb={5}>
+            <Box mt='18px' mb={6}>
                 <TopicChipBar topics={TOPICS} active={activeTopic} onChange={setActiveTopic} />
             </Box>
 
@@ -68,29 +82,22 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
             )}
 
             {hero && (
-                <Box mb={6}>
+                <Grid
+                    templateColumns={{ base: '1fr', md: '1.35fr 1fr' }}
+                    gap={4}
+                    mb={4}
+                >
                     <HeroCard
                         title={hero.title}
                         link={hero.link}
                         source={hero.sourceTitle}
                         publishedAt={hero.pubDate ? new Date(hero.pubDate) : null}
-                        sideItems={sideItems}
                         isSaved={isSaved(hero.link)}
                         onRead={() => markRead(hero.link)}
-                        onSave={() =>
-                            toggleSaved({
-                                title: hero.title,
-                                link: hero.link,
-                                source: hero.sourceTitle,
-                                publishedAt: hero.pubDate,
-                                matchedKeywords: TOPICS.filter((kw) =>
-                                    hero.title.toLowerCase().includes(kw.toLowerCase()),
-                                ),
-                                savedAt: '',
-                            })
-                        }
+                        onSave={() => toggleSaved(toSavedArticle(hero))}
                     />
-                </Box>
+                    {railItems.length > 0 && <ReadingList items={railItems} />}
+                </Grid>
             )}
 
             <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
@@ -109,16 +116,7 @@ const IndexPage: React.FC<PageProps<DataProps>> = ({ data }) => {
                             isRead={isRead(post.link)}
                             isSaved={isSaved(post.link)}
                             onRead={() => markRead(post.link)}
-                            onSave={() =>
-                                toggleSaved({
-                                    title: post.title,
-                                    link: post.link,
-                                    source: post.sourceTitle,
-                                    publishedAt: post.pubDate,
-                                    matchedKeywords,
-                                    savedAt: '',
-                                })
-                            }
+                            onSave={() => toggleSaved(toSavedArticle(post))}
                         />
                     );
                 })}

--- a/src/pages/saved.tsx
+++ b/src/pages/saved.tsx
@@ -37,7 +37,7 @@ const SavedPage: React.FC = () => {
                 />
             )}
 
-            <Box display='flex' flexDirection='column' gap={3}>
+            <Box display='flex' flexDirection='column' gap={4}>
                 {savedArticles.map((article: SavedArticle) => (
                     <ArticleCard
                         key={article.link}

--- a/src/theme/mizuo.ts
+++ b/src/theme/mizuo.ts
@@ -1,48 +1,93 @@
 import { extendTheme } from '@chakra-ui/react';
 
+// Mizuo（水尾）デザインシステム — Claude Designプロジェクトのトークンを再現
+// ティールがブランド・アクセント・リンク、アンバーが唯一のハイライト（イチオシ・連番）
+// それ以外はウォームニュートラルのグレー
 const colors = {
+    // teal スケール（brand / accent / links / active states）
     brand: {
-        50: '#f0faf5',
-        100: '#c6ead8',
-        200: '#9bd9bb',
-        300: '#6ec89d',
-        400: '#42b780',
-        500: '#2d9e68',
-        600: '#1e7d50',
-        700: '#145c39',
-        800: '#0b3b24',
-        900: '#041a10',
+        50: '#f0f6f4', // teal-050
+        100: '#e5f0ed', // teal-100 — soft accent surface
+        200: '#cfe3de',
+        300: '#7fb3a8', // teal-300
+        400: '#4f998b',
+        500: '#157a6a', // teal-600
+        600: '#0e5f52', // teal-700 — primary accent
+        700: '#0c4c43', // teal-800
+        800: '#0a3d36', // teal-900
+        900: '#082f2a',
     },
-    hero: {
-        bg: '#1C3B35',
-        text: '#ffffff',
-        muted: 'rgba(255,255,255,0.65)',
-        badge: '#4CAF7D',
-        number: '#6ECFA0',
+    // amber（ハイライト専用: イチオシ・連番）
+    amber: {
+        100: '#faf0dd', // soft amber surface
+        200: '#f6dcae',
+        500: '#e8a33d', // highlight
+        600: '#b9791f',
     },
+    // semantic — brand / interaction
+    accent: {
+        base: '#0e5f52', // teal-700
+        hover: '#0c4c43', // teal-800
+        soft: '#e5f0ed', // teal-100
+    },
+    highlight: {
+        base: '#e8a33d', // amber-500
+        soft: '#faf0dd', // amber-100
+    },
+    // warm-neutral gray（semantic — text / surfaces / lines）
     neutral: {
-        bg: '#F7F7F5',
-        surface: '#ffffff',
-        border: '#E8E8E6',
-        chip: '#EFEFEF',
-        chipActive: '#1A1A1A',
-        textPrimary: '#1A1A1A',
-        textSecondary: '#6B6B6B',
-        textMuted: '#9B9B9B',
+        bg: '#f4f6f5', // gray-050 — page background
+        surface: '#ffffff', // surface-card
+        hover: '#eef1f0', // gray-100 — surface-hover
+        border: '#e3e8e6', // gray-200 — borders / hairlines
+        textPrimary: '#1c2a27', // gray-900 — ink / headings
+        textSecondary: '#5b6b66', // gray-600 — body / faint
+        textMuted: '#8a9691', // gray-500 — muted meta
+    },
+    // イチオシのヒーローカード（teal surface, white text）
+    hero: {
+        bg: '#0e5f52', // surface-feature
+        text: '#ffffff',
+        summary: 'rgba(255,255,255,0.78)',
+        muted: 'rgba(255,255,255,0.65)',
+        star: 'rgba(255,255,255,0.55)',
+        badgeBg: 'rgba(232,163,61,0.22)',
+        badgeText: '#f6dcae', // amber-200
     },
 };
 
 const fonts = {
     heading:
-        '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-    body: '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+    body: '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+};
+
+// Mizuo type scale
+const fontSizes = {
+    xs: '0.719rem', // 11.5px — tags, ordinals
+    sm: '0.813rem', // 13px — meta, chips
+    md: '0.875rem', // 14px — card titles, body
+    lg: '0.938rem', // 15px
+    xl: '1.125rem', // 18px — wordmark, section titles
+    '2xl': '1.313rem', // 21px — feature-card title
+    '3xl': '1.625rem', // 26px — page greeting
+};
+
+const radii = {
+    card: '14px',
+    chip: '9999px',
+};
+
+const shadows = {
+    card: '0 1px 3px rgba(28, 42, 39, 0.06)',
+    raised: '0 6px 16px rgba(28, 42, 39, 0.10)',
 };
 
 const styles = {
     global: {
         body: {
-            bg: colors.neutral.bg,
-            color: colors.neutral.textPrimary,
+            bg: 'neutral.bg',
+            color: 'neutral.textPrimary',
         },
     },
 };
@@ -50,57 +95,85 @@ const styles = {
 const components = {
     Button: {
         variants: {
-            tab: {
-                borderRadius: 'full',
+            // ヘッダーのピルナビ
+            navTab: {
+                borderRadius: 'chip',
                 fontWeight: 'medium',
-                fontSize: 'sm',
-                px: 4,
-                py: 2,
+                fontSize: 'md',
+                px: '0.875rem',
+                py: '0.5rem',
                 h: 'auto',
                 bg: 'transparent',
                 color: 'neutral.textSecondary',
-                _hover: { bg: 'neutral.chip' },
-                _active: {
-                    bg: 'white',
-                    color: 'neutral.textPrimary',
-                    shadow: 'sm',
-                },
+                _hover: { bg: 'neutral.hover' },
             },
+            // トピックフィルタのチップ（非アクティブ: 白地 + 実線ボーダー）
             chip: {
-                borderRadius: 'full',
+                borderRadius: 'chip',
                 fontWeight: 'medium',
-                fontSize: 'xs',
-                px: 3,
-                py: 1,
+                fontSize: 'sm',
+                lineHeight: 1.4,
+                px: '0.94rem',
+                py: '0.44rem',
                 h: 'auto',
-                bg: 'neutral.chip',
-                color: 'neutral.textSecondary',
-                _hover: { bg: 'neutral.border' },
-                _active: {
-                    bg: 'neutral.chipActive',
-                    color: 'white',
-                },
+                bg: 'neutral.surface',
+                borderWidth: '1px',
+                borderColor: 'neutral.border',
+                color: 'neutral.textPrimary',
+                _hover: { bg: 'accent.soft', borderColor: 'accent.soft' },
+            },
+            // 「トピックを追加」の破線チップ
+            chipAdd: {
+                borderRadius: 'chip',
+                fontWeight: 'medium',
+                fontSize: 'sm',
+                lineHeight: 1.4,
+                px: '0.94rem',
+                py: '0.44rem',
+                h: 'auto',
+                bg: 'transparent',
+                borderWidth: '1px',
+                borderStyle: 'dashed',
+                borderColor: 'neutral.textMuted',
+                color: 'neutral.textMuted',
+                _hover: { bg: 'neutral.hover' },
             },
         },
     },
     Link: {
         baseStyle: {
-            _hover: { textDecoration: 'none', color: 'brand.600' },
+            color: 'accent.base',
+            _hover: { textDecoration: 'none', color: 'accent.hover' },
         },
     },
     Badge: {
         baseStyle: {
-            borderRadius: 'full',
+            borderRadius: 'chip',
             fontWeight: 'medium',
             textTransform: 'none',
-            fontSize: '2xs',
+            fontSize: 'xs',
+            lineHeight: 1.5,
+            px: '0.56rem',
+            py: '0.19rem',
+            whiteSpace: 'nowrap',
         },
+        variants: {
+            // トピックタグ（teal soft）
+            accent: { bg: 'accent.soft', color: 'accent.base' },
+            // イチオシ・寄り道マーカー（amber）
+            amber: { bg: 'highlight.soft', color: 'amber.600' },
+            subtle: { bg: 'neutral.hover', color: 'neutral.textSecondary' },
+        },
+        defaultProps: { variant: 'accent' },
     },
 };
 
 export const mizuoTheme = extendTheme({
     colors,
     fonts,
+    fontSizes,
+    radii,
+    shadows,
     styles,
     components,
     config: {


### PR DESCRIPTION
## 概要

このブランチには以下の3つの変更が含まれます。

1. **保存済み機能**（ローカルストレージ + ☆トグル、/saved/ ページ）
2. **SupabaseとGitHub OAuthによる保存記事の永続化**
3. **Mizuoデザインシステムの完全適用**

## Mizuoデザイン適用の詳細

- **根本原因の修正**: Chakraテーマがサイトに一切適用されていなかった。`@chakra-ui/gatsby-plugin` はテーマを `src/@chakra-ui/gatsby-plugin/theme.ts` のシャドウイングで受け取る仕組みだが、このファイルが存在しなかった
- テーマをClaude Designの「Tech Blog Aggregator Design System」トークンで全面書き換え（teal `#0e5f52` アクセント / amber `#e8a33d` ハイライト / ウォームグレー）
- HeroCardをティール面のFeatureCard仕様に刷新、「続けて読む」をReadingList（白カード・アンバー連番）として分離
- NavBar（ティールワードマーク + accent-softピルナビ）・TopicChipBar（ボーダーチップ + 破線の追加チップ）・ArticleCard・GreetingHeaderをデザイン仕様に追従
- 未読込だったNoto Sans JPの読み込みを追加

## 確認

- `tsc --noEmit` / `gatsby build` 成功
- ドラフトデプロイで表示確認済み: https://6a51c00979a634f8f4f7afcc--soft-kheer-8e0b97.netlify.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9pFdJSDgEGi2mK1TSgnVv