### PR TITLE
fix: 保存記事移行のupsertに必要なUPDATE権限を追加

### DIFF
--- a/supabase/migrations/20260711110000_grant_update_saved_articles.sql
+++ b/supabase/migrations/20260711110000_grant_update_saved_articles.sql
@@ -1,0 +1,7 @@
+-- upsert（INSERT ... ON CONFLICT DO UPDATE）はUPDATE権限とRLSポリシーを要求するため追加する
+grant update on public.saved_articles to authenticated;
+
+create policy "自分の保存記事のみ更新可"
+  on public.saved_articles for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 概要
localStorage→Supabase移行で「保存記事の移行に失敗しました」エラーが出る問題の修正（#11 のフォローアップ）。

## 根本原因
移行処理の `upsert`（`INSERT ... ON CONFLICT DO UPDATE`）はテーブルのUPDATE権限を要求するが、#11 のGRANTは select/insert/delete のみだった。RLSのUPDATEポリシーも未定義。

## 変更内容
- `authenticated` ロールへ update を付与
- 自分の行のみ更新可能なRLSポリシーを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9pFdJSDgEGi2mK1TSgnVv